### PR TITLE
fix(deps): update entity refs inside scripts on rename

### DIFF
--- a/dependency_updater.py
+++ b/dependency_updater.py
@@ -250,9 +250,12 @@ class DependencyUpdater:
 
             # SCRIPTS
             elif entity_id.startswith("script."):
-                # Prüfe ob Entity im Script verwendet wird
-                state_str = json.dumps(attributes)
-                if old_entity_id in state_str:
+                # Script state attributes don't contain the sequence, so checking
+                # them never finds entity references. Fetch the real config via REST
+                # and check there (same approach as automations below).
+                config = await self.get_script_config(entity_id)
+                if config and old_entity_id in json.dumps(config):
+                    logger.info(f"Found script {entity_id} using {old_entity_id}")
                     success = await self.update_script_entities(entity_id, old_entity_id, new_entity_id)
                     if success:
                         results["scripts"]["success"].append(entity_id)


### PR DESCRIPTION
## Problem

After renaming an entity, scripts that referenced the old entity_id were left
untouched — Spook surfaced them as *"unknown entities used in script.*"* (e.g.
`switch.balkon_bewasserung_ventil` still referenced in `script.balkon_bewasserung_jetzt`,
`script.balkon_pumpe_priming`, `script.balkon_wasser_stopp`).

## Root cause

In `dependency_updater.py` the SCRIPTS branch filtered candidates with
`old_entity_id in json.dumps(attributes)` — but a `script.*` entity's **state
attributes never contain the `sequence`** (only `friendly_name`, `last_triggered`,
`mode`, …). So the filter was always `False` for entities referenced inside the
sequence, and `update_script_entities()` — which already does the correct recursive
replacement — was never reached.

Automations were already handled correctly: their full config is fetched via REST
and the check runs against that.

## Fix

Treat scripts like automations: fetch the full script config via REST
(`get_script_config`) and check `old_entity_id` against it before updating. Also
avoids the false-`failed` problem (since `update_script_entities()` returns `False`
both on "no match" and on error).

## Notes

- `dependency_scanner.py` is dead code (not imported anywhere); the only active
  rename path is `update_all_dependencies` in `web_ui.py`, so this is the single fix site.
- This does **not** retro-fix already-broken scripts — those still point at the
  now-gone old entity_id and need a one-off `old -> new` pass (or manual edit).

## Testing

- Syntax check passes; lines < 120; no unused variables.
- Linters (flake8/black/isort) run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)