### PR TITLE
chore: repository professionalization (templates, CONTRIBUTING, tests, CI, governance)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: "🐛 Bug report"
+description: Report a problem with the Entity Manager add-on
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! This add-on is **beta software** —
+        please include as much detail as possible so we can reproduce the issue.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched existing issues and this has not been reported yet
+          required: true
+        - label: I am running the latest available version of the add-on
+          required: true
+  - type: input
+    id: addon-version
+    attributes:
+      label: Add-on version
+      description: See Settings → Add-ons → Entity Manager (e.g. 1.0.3-beta)
+      placeholder: "1.0.3-beta"
+    validations:
+      required: true
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      placeholder: "2025.7.2"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the problem?
+      placeholder: |
+        1. Open the add-on
+        2. Select area '...'
+        3. Click '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Add-on logs
+      description: Relevant log output (Settings → Add-ons → Entity Manager → Logs). This is automatically formatted, no backticks needed.
+      render: shell
+  - type: dropdown
+    id: integration
+    attributes:
+      label: Affected integration (if relevant)
+      description: Especially for device swap / Z2M issues.
+      options:
+        - "Not applicable"
+        - "Zigbee2MQTT (MQTT)"
+        - "Matter"
+        - "ZHA"
+        - "Other"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/Skjall/home-assistant-entity-manager/discussions
+    about: For general questions and usage help, please use Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: "✨ Feature request"
+description: Suggest an idea or improvement for the Entity Manager add-on
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched existing issues and this has not been requested yet
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what is missing or cumbersome today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you have thought about.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+  Thanks for contributing! Please target the `next-release` branch, NOT `main`.
+  `main` is the release branch and is only updated via next-release.
+-->
+
+## Description
+
+<!-- What does this PR change and why? -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
+- [ ] 📝 Documentation / chore
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] My PR targets the **`next-release`** branch
+- [ ] My branch is up to date with `next-release`
+- [ ] Lint passes locally: `flake8`, `black --check --line-length 120`, `isort --check-only --profile black --line-length 120`
+- [ ] New/changed Python functions have type hints and docstrings
+- [ ] Log messages are in English (UI strings may be localized via `translations/`)
+- [ ] If frontend changed: ran `npm run build:css` (Tailwind purges unused classes)
+- [ ] I tested the change (describe how below)
+
+## How was this tested?
+
+<!-- Manual steps, affected integration (Z2M / Matter / ZHA), etc. -->

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,41 @@
+# Label definitions, synced by .github/workflows/labels.yml
+# Status labels are mutually exclusive (enforced by issue-governance.yml).
+
+# --- Status (exclusive) ---
+- name: "status: triage"
+  color: "ededed"
+  description: "Needs triage / not started"
+- name: "status: in progress"
+  color: "0e8a16"
+  description: "Actively being worked on"
+- name: "status: in review"
+  color: "fbca04"
+  description: "A PR is open / under review"
+- name: "status: blocked"
+  color: "b60205"
+  description: "Blocked by something else"
+- name: "status: done"
+  color: "5319e7"
+  description: "Completed / closed"
+
+# --- Type ---
+- name: "type: bug"
+  color: "d73a4a"
+  description: "Something is not working"
+- name: "type: enhancement"
+  color: "a2eeef"
+  description: "New feature or improvement"
+- name: "type: docs"
+  color: "0075ca"
+  description: "Documentation"
+- name: "type: chore"
+  color: "cfd3d7"
+  description: "Maintenance / tooling"
+
+# --- Process ---
+- name: "needs issue"
+  color: "e99695"
+  description: "PR without a linked issue"
+- name: "duplicate"
+  color: "cfd3d7"
+  description: "This already exists"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "*.md"
       - "LICENSE"
   pull_request:
-    branches: [main]
+    branches: [main, next-release]
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,42 @@ jobs:
         run: |
           isort --check-only --profile black --line-length 120 --skip-glob="venv*" --skip-glob="legacy/*" --skip-glob="node_modules/*" .
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+
+      - name: Run pytest
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install + build frontend
+        run: |
+          npm ci
+          npm run build
+
   build:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -1,0 +1,46 @@
+name: Duplicate issue hint
+
+# On a new issue, search for similar existing issues by title keywords and post a
+# best-effort comment linking them. Does not close anything — just a pointer.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  similar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const issue = context.payload.issue;
+
+            // keywords from the title (drop short/common words)
+            const stop = new Set(["the", "and", "for", "with", "that", "this", "when", "from", "into", "does", "not"]);
+            const words = (issue.title || "")
+              .toLowerCase()
+              .replace(/[^a-z0-9 ]/g, " ")
+              .split(/\s+/)
+              .filter((w) => w.length >= 4 && !stop.has(w))
+              .slice(0, 6);
+            if (words.length === 0) return;
+
+            const q = `repo:${repo.owner}/${repo.repo} is:issue ${words.join(" ")}`;
+            const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 6 });
+
+            const matches = res.data.items
+              .filter((it) => it.number !== issue.number && !it.pull_request)
+              .slice(0, 5);
+            if (matches.length === 0) return;
+
+            const list = matches.map((it) => `- #${it.number} ${it.title} (${it.state})`).join("\n");
+            await github.rest.issues.createComment({
+              ...repo,
+              issue_number: issue.number,
+              body: `🔎 Possibly related existing issues — please check for duplicates:\n\n${list}`,
+            });

--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -1,0 +1,74 @@
+name: Issue governance
+
+# Keeps a single, mutually-exclusive status label on issues and moves it
+# automatically through the lifecycle (triage -> in progress -> in review -> done).
+
+on:
+  issues:
+    types: [opened, reopened, assigned, closed, labeled]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const STATUSES = [
+              "status: triage",
+              "status: in progress",
+              "status: in review",
+              "status: blocked",
+              "status: done",
+            ];
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+
+            async function setStatus(issue_number, target) {
+              const current = (
+                await github.rest.issues.listLabelsOnIssue({ ...repo, issue_number })
+              ).data.map((l) => l.name);
+              // exclusive: drop every other status label
+              for (const s of STATUSES) {
+                if (s !== target && current.includes(s)) {
+                  await github.rest.issues
+                    .removeLabel({ ...repo, issue_number, name: s })
+                    .catch(() => {});
+                }
+              }
+              if (target && !current.includes(target)) {
+                await github.rest.issues.addLabels({ ...repo, issue_number, labels: [target] });
+              }
+            }
+
+            const action = context.payload.action;
+
+            if (context.eventName === "issues") {
+              const n = context.payload.issue.number;
+              if (action === "opened") await setStatus(n, "status: triage");
+              else if (action === "reopened") await setStatus(n, "status: triage");
+              else if (action === "assigned") await setStatus(n, "status: in progress");
+              else if (action === "closed") await setStatus(n, "status: done");
+              else if (action === "labeled") {
+                // someone set a status label manually -> enforce exclusivity
+                const added = context.payload.label && context.payload.label.name;
+                if (STATUSES.includes(added)) await setStatus(n, added);
+              }
+            }
+
+            if (context.eventName === "pull_request_target") {
+              // move every issue referenced via Closes/Fixes/Resolves #N to "in review"
+              const body = context.payload.pull_request.body || "";
+              const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+              const seen = new Set();
+              let m;
+              while ((m = re.exec(body)) !== null) seen.add(parseInt(m[1], 10));
+              for (const n of seen) {
+                await setStatus(n, "status: in review").catch(() => {});
+              }
+            }

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,21 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/labels.yml"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -1,0 +1,43 @@
+name: PR linked issue
+
+# Every PR must reference an issue (Closes/Fixes/Resolves #N). Otherwise it gets
+# a "needs issue" label and a failing check until an issue is linked.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i;
+            const linked = re.test(body);
+            const LABEL = "needs issue";
+
+            const labels = (
+              await github.rest.issues.listLabelsOnIssue({ ...repo, issue_number: pr.number })
+            ).data.map((l) => l.name);
+
+            if (linked) {
+              if (labels.includes(LABEL)) {
+                await github.rest.issues.removeLabel({ ...repo, issue_number: pr.number, name: LABEL }).catch(() => {});
+              }
+            } else {
+              if (!labels.includes(LABEL)) {
+                await github.rest.issues.addLabels({ ...repo, issue_number: pr.number, labels: [LABEL] });
+              }
+              core.setFailed(
+                "This PR does not reference an issue. Add 'Closes #<issue>' (or Fixes/Resolves) to the description."
+              );
+            }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Local checks mirroring the CI (lint + tests). Install once with:
+#   pip install pre-commit && pre-commit install
+# Run on all files:
+#   pre-commit run --all-files
+exclude: '^(venv.*|legacy|node_modules|static)/'
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: ["--line-length=120", "--target-version=py312"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile=black", "--line-length=120"]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        args:
+          - "--select=E9,F63,F7,F82,E741,E722,F401,F402,F541,F841"
+          - "--exclude=venv*,legacy,node_modules"
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,22 @@ Run these before opening a PR (the CI enforces them):
 flake8 . --exclude=venv*,legacy,node_modules
 black --check --line-length 120 --target-version py312 .
 isort --check-only --profile black --line-length 120 .
+pytest
 ```
+
+Or install the **pre-commit hook**, which runs the same checks (black/isort/flake8 + pytest)
+automatically before every commit:
+
+```bash
+pip install pre-commit && pip install -r requirements-test.txt
+pre-commit install
+pre-commit run --all-files   # optional: run once over everything
+```
+
+### Tests
+
+Unit tests live in `tests/` and run offline (no Home Assistant required) — they mock the
+clients. Run them with `pytest`. Please add/extend tests for backend logic you change.
 
 - **Python:** Black (line length 120), isort (black profile), flake8. All functions need type hints and docstrings.
 - **Logs in English:** all log output (`logger.*` and job/progress logs) must be English. User-facing UI strings are localized via `translations/ui/*.json`.
@@ -106,6 +121,20 @@ The PR template lists the full checklist. In short:
 3. Frontend changes include a rebuilt CSS (`npm run build:css`).
 4. Describe how you tested the change (and which integration: Z2M / Matter / ZHA).
 5. Open the PR against **`next-release`**.
+
+## Issue & PR process
+
+Issues and PRs are kept tidy with a few automated rules:
+
+- **Every PR must reference an issue** — put `Closes #123` (or `Fixes`/`Resolves`) in the
+  description. PRs without a linked issue get a `needs issue` label and a failing check.
+- **Status labels are exclusive and automatic** — only one is ever set:
+  `status: triage` (new) → `status: in progress` (assigned) → `status: in review`
+  (a PR links the issue) → `status: done` (closed).
+- **Duplicate hint** — new issues get a comment linking possibly-related existing issues.
+
+Typical flow: open an issue (→ `triage`) → assign yourself (→ `in progress`) → open a PR
+with `Closes #N` against `next-release` (→ issue `in review`) → merge closes the issue (→ `done`).
 
 ## Releasing (maintainers)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing
+
+Thanks for your interest in improving the **Home Assistant Entity Manager** add-on!
+This document describes the branching model, how to set up a development environment,
+and the conventions we follow.
+
+> This add-on is **beta software**. Contributions, bug reports and ideas are very welcome.
+
+## Branching model
+
+| Branch | Purpose |
+|---|---|
+| `main` | **Release branch.** Always deployable. Each push that changes `config.json` creates a tagged release. Never push directly. |
+| `next-release` | **Integration branch.** All feature/fix branches are merged here first; CI runs on every push. |
+| `feature/*`, `fix/*`, `chore/*` | Your working branches, created from `next-release`. |
+
+**Flow:** `feature/*` → PR into **`next-release`** → (once stable) `next-release` → `main` → release.
+
+> ⚠️ **Always target `next-release` with your Pull Request, not `main`.**
+
+## Getting started
+
+### Prerequisites
+
+- Node.js (for the frontend build) and `npm`
+- Docker (to build/run the add-on)
+- Python 3.12+ (for linting locally)
+
+### Setup
+
+```bash
+git clone https://github.com/Skjall/home-assistant-entity-manager.git
+cd home-assistant-entity-manager
+git checkout next-release
+git checkout -b feature/my-change
+
+npm ci          # install frontend dependencies
+npm run build   # build CSS/JS + copy assets
+```
+
+### Build & run the add-on locally
+
+```bash
+docker build --build-arg BUILD_FROM="ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.20" -t local/entity_manager .
+docker run --rm -it -p 5000:5000 \
+  -e HA_URL="http://your-ha-instance:8123" \
+  -e HA_TOKEN="your-long-lived-token" \
+  local/entity_manager
+```
+
+### Frontend changes
+
+The CSS is built with Tailwind, which **purges unused classes**. After adding or
+changing utility classes in `templates/` or `src/`, rebuild:
+
+```bash
+npm run build:css
+```
+
+## Working on several changes in parallel
+
+If you work on multiple independent changes at the same time (for example several
+Claude Code sessions), give each one its own **git worktree** and branch so they
+never collide in the main checkout and each lands in a separate branch:
+
+```bash
+scripts/feature-worktree.sh dashboard-export
+#  -> ../home-assistant-entity-manager-dashboard-export
+#     branch: feature/dashboard-export (based on origin/next-release)
+
+cd ../home-assistant-entity-manager-dashboard-export
+# ... make changes, commit ...
+git push -u origin feature/dashboard-export      # open a PR against next-release
+```
+
+Each worktree is an independent working directory on its own branch, so parallel
+work stays isolated — no patching changes back and forth between checkouts. Test a
+worktree in isolation (`./deploy.sh` from inside it), and remove it once its PR is
+merged:
+
+```bash
+git worktree remove ../home-assistant-entity-manager-dashboard-export
+```
+
+## Code style & conventions
+
+Run these before opening a PR (the CI enforces them):
+
+```bash
+flake8 . --exclude=venv*,legacy,node_modules
+black --check --line-length 120 --target-version py312 .
+isort --check-only --profile black --line-length 120 .
+```
+
+- **Python:** Black (line length 120), isort (black profile), flake8. All functions need type hints and docstrings.
+- **Logs in English:** all log output (`logger.*` and job/progress logs) must be English. User-facing UI strings are localized via `translations/ui/*.json`.
+- **Translations:** edit `translations/ui/<lang>.json` directly (de, en, es, fr) — there is no external translation service.
+- **Commits:** use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `chore:`, `docs:`).
+
+## Pull request checklist
+
+The PR template lists the full checklist. In short:
+
+1. Branch off `next-release` and keep it up to date.
+2. Lint passes (flake8 / black / isort) and JSON files are valid.
+3. Frontend changes include a rebuilt CSS (`npm run build:css`).
+4. Describe how you tested the change (and which integration: Z2M / Matter / ZHA).
+5. Open the PR against **`next-release`**.
+
+## Releasing (maintainers)
+
+1. Merge `next-release` into `main`.
+2. Bump `version` in `config.json` (keeps the `-beta` suffix for now).
+3. The `Release` workflow tags `v<version>` and publishes a GitHub release automatically.
+
+## Reporting bugs / requesting features
+
+Please use the GitHub issue templates (Bug report / Feature request). For general
+questions, use [Discussions](https://github.com/Skjall/home-assistant-entity-manager/discussions).

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ A Home Assistant Add-on for standardizing and managing entity names according to
 - **Batch Entity Renaming**: Rename multiple entities according to a standardized pattern
 - **Logical Naming Convention**: Follows the pattern `{area}.{device_type}.{location/name}`
 - **Character Normalization**: Automatically normalizes special characters for entity IDs
-- **Dependency Tracking**: Finds and updates entity references in automations and scenes
+- **Dependency Tracking**: Finds and updates entity references in automations, scenes, scripts and dashboards
+- **Device Swap**: Replace a physical device with a new one — re-maps all references, carries over IDs/friendly names, and is crash-safe/resumable
+- **Integration Bridge**: Native rename/removal for Zigbee2MQTT (via MQTT), Matter and ZHA — keeps Z2M friendly names in sync and prevents re-population after deletion
+- **Z2M Name Drift**: Highlights devices whose Zigbee2MQTT name differs from the HA name and lets you sync them
+- **Learn Translations**: Save a suffix translation to the mapping list directly from the entity editor
 - **Label Management**: Track entity quality and processing status
 - **Web Interface**: Visualize and manage entities through an intuitive UI
-- **Safe Operations**: Dry-run mode and comprehensive validation before changes
+- **Safe Operations**: Preview and comprehensive validation before changes
 
 ## Requirements
 
@@ -34,7 +38,7 @@ A Home Assistant Add-on for standardizing and managing entity names according to
 2. Click the three dots menu → Repositories
 3. Add this repository: `https://github.com/Skjall/home-assistant-entity-manager`
 4. Click "Add"
-5. Find "Entity Manager (Beta)" in the add-on store
+5. Find "Entity Manager" in the add-on store
 6. Click on it and then click "Install"
 7. Start the add-on
 8. Click "OPEN WEB UI" to access the interface
@@ -160,7 +164,7 @@ Check the Add-on logs in Supervisor → Entity Manager → Logs
 
 ```bash
 # Build for your architecture
-docker build --build-arg BUILD_FROM="ghcr.io/home-assistant/amd64-base-python:3.12" -t local/entity_manager .
+docker build --build-arg BUILD_FROM="ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.20" -t local/entity_manager .
 
 # Run locally for testing
 docker run --rm -it -p 5000:5000 \
@@ -171,20 +175,15 @@ docker run --rm -it -p 5000:5000 \
 
 ## Contributing
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Ensure tests pass and coverage is maintained
-4. Commit your changes (`git commit -m 'Add amazing feature'`)
-5. Push to the branch (`git push origin feature/amazing-feature`)
-6. Open a Pull Request
+Contributions are welcome! Please read **[CONTRIBUTING.md](CONTRIBUTING.md)** for the
+full guide. In short:
 
-### Development Guidelines
+1. Fork the repository and branch off **`next-release`** (`git checkout -b feature/amazing-feature next-release`)
+2. Make your changes; ensure `flake8` / `black` / `isort` pass
+3. Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, …)
+4. Open a Pull Request **against `next-release`** (not `main`)
 
-- All code must have type hints
-- All functions must have docstrings
-- Test coverage must be maintained above 80%
-- Follow Home Assistant development guidelines
-- Use semantic commit messages
+`main` is the release branch and is only updated via `next-release`.
 
 ## License
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the add-on modules (in the repo root) importable from tests/.
+sys.path.insert(0, os.path.dirname(__file__))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*
+addopts = -q

--- a/renovate.json
+++ b/renovate.json
@@ -20,46 +20,6 @@
       ]
     },
     {
-      "matchFileNames": [
-        "requirements-test.txt"
-      ],
-      "matchPackageNames": [
-        "pytest-homeassistant-custom-component"
-      ],
-      "allowedVersions": "<0.13.46",
-      "description": "pytest-homeassistant-custom-component >=0.13.46 requires Python 3.11+"
-    },
-    {
-      "matchFileNames": [
-        "requirements-test.txt"
-      ],
-      "matchPackageNames": [
-        "pytest-asyncio"
-      ],
-      "allowedVersions": "0.20.3",
-      "description": "Pinned due to pytest-homeassistant-custom-component dependency"
-    },
-    {
-      "matchFileNames": [
-        "requirements-test.txt"
-      ],
-      "matchPackageNames": [
-        "pytest-cov"
-      ],
-      "allowedVersions": "3.0.0",
-      "description": "Pinned due to pytest-homeassistant-custom-component dependency"
-    },
-    {
-      "matchFileNames": [
-        "requirements-test.txt"
-      ],
-      "matchPackageNames": [
-        "pytest"
-      ],
-      "allowedVersions": "7.3.1",
-      "description": "Pinned due to pytest-homeassistant-custom-component dependency"
-    },
-    {
       "matchManagers": [
         "npm"
       ],
@@ -81,6 +41,24 @@
         "esbuild"
       ],
       "groupName": "Build dependencies"
+    },
+    {
+      "description": "Auto-merge low-risk updates once CI is green (requires branch protection on next-release)",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Never auto-merge major updates — review manually",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
     }
   ],
   "vulnerabilityAlerts": {
@@ -89,10 +67,8 @@
   "dependencyDashboard": true,
   "prConcurrentLimit": 2,
   "labels": [
-    "dependencies"
-  ],
-  "assignees": [
-    "@renovate-bot"
+    "dependencies",
+    "type: chore"
   ],
   "reviewers": [
     "Skjall"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+# Test-only dependencies (not shipped in the add-on image)
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/scripts/feature-worktree.sh
+++ b/scripts/feature-worktree.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# feature-worktree.sh — create an isolated git worktree + feature branch.
+#
+# For working on several changes in parallel (e.g. multiple Claude sessions):
+# each task gets its own working directory and its own branch off `next-release`,
+# so the changes never collide in the main checkout.
+#
+# Usage:
+#   scripts/feature-worktree.sh <short-name> [base-branch]
+#
+# Examples:
+#   scripts/feature-worktree.sh dashboard-export
+#   scripts/feature-worktree.sh fix-z2m-timeout fix
+#
+# Creates:
+#   ../<repo>-<slug>      worktree directory (sibling of the repo)
+#   feature/<slug>        branch, based on origin/next-release
+#
+# When done:
+#   cd <worktree>
+#   git push -u origin <branch>        # then open a PR against next-release
+#   cd -                               # back to main checkout
+#   git worktree remove ../<repo>-<slug>
+#
+set -euo pipefail
+
+name="${1:?Usage: feature-worktree.sh <short-name> [type: feature|fix|chore]}"
+type="${2:-feature}"
+
+# slugify: lowercase, spaces/underscores -> dashes, strip junk
+slug="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | tr ' _' '--' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+[ -n "$slug" ] || { echo "error: name produced an empty slug" >&2; exit 1; }
+
+branch="${type}/${slug}"
+repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+dir="../${repo_name}-${slug}"
+
+git fetch origin --quiet
+
+if git show-ref --quiet "refs/heads/${branch}"; then
+  echo "error: branch '${branch}' already exists" >&2
+  exit 1
+fi
+
+git worktree add "$dir" -b "$branch" origin/next-release
+
+cat <<EOF
+
+✓ Worktree: ${dir}
+✓ Branch:   ${branch}  (based on origin/next-release)
+
+Next:
+  cd "${dir}"
+  # ... make changes, commit ...
+  git push -u origin ${branch}        # then open a PR against 'next-release'
+
+Cleanup when merged:
+  git worktree remove "${dir}"
+EOF

--- a/tests/test_bridge_mqtt.py
+++ b/tests/test_bridge_mqtt.py
@@ -1,0 +1,65 @@
+"""Tests for the MQTT bridge callbacks: device-name cache and transaction correlation."""
+
+import asyncio
+import json
+import threading
+
+from bridge_mqtt import MqttBridge
+
+
+class _Msg:
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode("utf-8")
+
+
+def _bridge():
+    # constructing does not connect; we drive the callbacks directly
+    b = MqttBridge("host", 1883, base_topic="zigbee2mqtt")
+    b._connected.set()
+    return b
+
+
+def test_on_devices_populates_name_cache():
+    b = _bridge()
+    b._on_devices(
+        None,
+        None,
+        _Msg(
+            [{"ieee_address": "0xabc", "friendly_name": "Lamp"}, {"ieee_address": "0xdef", "friendly_name": "Sensor"}]
+        ),
+    )
+    names = asyncio.run(b.get_z2m_names())
+    assert names == {"0xabc": "Lamp", "0xdef": "Sensor"}
+
+
+def test_get_z2m_names_returns_copy():
+    b = _bridge()
+    b._on_devices(None, None, _Msg([{"ieee_address": "0xabc", "friendly_name": "Lamp"}]))
+    names = asyncio.run(b.get_z2m_names())
+    names["0xabc"] = "Mutated"
+    again = asyncio.run(b.get_z2m_names())
+    assert again["0xabc"] == "Lamp"
+
+
+def test_on_message_correlates_transaction():
+    b = _bridge()
+    ev = threading.Event()
+    b._pending["em_1"] = {"event": ev, "result": None}
+    b._on_message(None, None, _Msg({"transaction": "em_1", "status": "ok"}))
+    assert ev.is_set()
+    assert b._pending["em_1"]["result"]["status"] == "ok"
+
+
+def test_on_message_ignores_unknown_transaction():
+    b = _bridge()
+    # no pending entry -> must not raise
+    b._on_message(None, None, _Msg({"transaction": "nope", "status": "ok"}))
+
+
+def test_on_message_ignores_non_json():
+    b = _bridge()
+
+    class _Raw:
+        payload = b"not-json"
+
+    b._on_message(None, None, _Raw())  # must not raise

--- a/tests/test_device_swap.py
+++ b/tests/test_device_swap.py
@@ -1,0 +1,243 @@
+"""Tests for the device swap engine: mapping, prefix swap, friendly names, executor flow."""
+
+import device_swap
+from device_swap import (
+    SwapExecutor,
+    SwapJobStore,
+    _common_prefix_tokens,
+    _entity_name,
+    propose_mapping,
+)
+
+# --------------------------------------------------------------------------- #
+# Pure helpers: prefix / suffix
+# --------------------------------------------------------------------------- #
+
+
+def test_common_prefix_tokens():
+    obj_ids = ["kuche_fenster_zustand", "kuche_fenster_batterie", "kuche_fenster_firmware"]
+    assert _common_prefix_tokens(obj_ids) == ["kuche", "fenster"]
+
+
+def test_common_prefix_keeps_last_token():
+    # last token always survives so the suffix is never empty
+    assert _common_prefix_tokens(["kuche_fenster_zustand"]) == ["kuche", "fenster"]
+
+
+def test_entity_name_strips_prefix():
+    assert _entity_name("sensor.kuche_fenster_ikea_batterie", ["kuche", "fenster", "ikea"]) == "batterie"
+
+
+# --------------------------------------------------------------------------- #
+# propose_mapping: exact suffix match, in-use filter
+# --------------------------------------------------------------------------- #
+
+
+def _ents(ids):
+    return [{"entity_id": i} for i in ids]
+
+
+OLD = _ents(
+    [
+        "sensor.kuche_fenster_batterie",
+        "sensor.kuche_fenster_batteriespannung",
+        "button.kuche_fenster_identifizieren",
+        "binary_sensor.kuche_fenster_zustand",
+    ]
+)
+NEW = _ents(
+    [
+        "sensor.kuche_fenster_ikea_batterie",
+        "sensor.kuche_fenster_ikea_batteriespannung",
+        "button.kuche_fenster_ikea_taste",
+        "binary_sensor.kuche_fenster_ikea_zustand",
+    ]
+)
+
+
+def test_propose_mapping_exact_suffix():
+    res = propose_mapping(OLD, NEW, {})
+    pairs = {p["old_entity_id"]: p["new_entity_id"] for p in res["pairs"]}
+    assert pairs["sensor.kuche_fenster_batterie"] == "sensor.kuche_fenster_ikea_batterie"
+    assert pairs["binary_sensor.kuche_fenster_zustand"] == "binary_sensor.kuche_fenster_ikea_zustand"
+
+
+def test_propose_mapping_no_match_stays_unmapped():
+    # identifizieren vs taste -> different suffix -> not auto-mapped
+    res = propose_mapping(OLD, NEW, {})
+    assert "button.kuche_fenster_identifizieren" not in {p["old_entity_id"] for p in res["pairs"]}
+    assert "button.kuche_fenster_identifizieren" in res["unmapped_old"]
+
+
+def test_propose_mapping_in_use_filter():
+    only = {"binary_sensor.kuche_fenster_zustand"}
+    res = propose_mapping(OLD, NEW, {}, in_use_ids=only)
+    assert [(p["old_entity_id"], p["new_entity_id"]) for p in res["pairs"]] == [
+        ("binary_sensor.kuche_fenster_zustand", "binary_sensor.kuche_fenster_ikea_zustand")
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# _swap_friendly: prefix swap on the friendly name
+# --------------------------------------------------------------------------- #
+
+
+def _executor_with_states(states_by_id):
+    ex = SwapExecutor.__new__(SwapExecutor)
+    ex.states_by_id = states_by_id
+    return ex
+
+
+def test_swap_friendly_keeps_suffix():
+    ex = _executor_with_states({"sensor.x": {"attributes": {"friendly_name": "Küche Fenster IKEA Batteriespannung"}}})
+    assert ex._swap_friendly("sensor.x", "Küche Fenster IKEA", "Küche Fenster") == "Küche Fenster Batteriespannung"
+
+
+def test_swap_friendly_no_prefix_match_returns_none():
+    ex = _executor_with_states({"sensor.x": {"attributes": {"friendly_name": "Something Else"}}})
+    assert ex._swap_friendly("sensor.x", "Küche Fenster IKEA", "Küche Fenster") is None
+
+
+# --------------------------------------------------------------------------- #
+# SwapExecutor.run: full flow with mock clients
+# --------------------------------------------------------------------------- #
+
+
+class _Rec:
+    def __init__(self):
+        self.calls = []
+
+
+class _DR(_Rec):
+    async def rename_device(self, dev, name):
+        self.calls.append(("dev", dev, name))
+
+
+class _ER(_Rec):
+    ws = object()
+
+    async def rename_entity(self, old, new, friendly=None):
+        self.calls.append((old, new))
+
+
+class _DU(_Rec):
+    async def update_all_dependencies(self, old, new, states=None):
+        self.calls.append((old, new))
+
+
+class _Bridge(_Rec):
+    async def rename_native(self, device_data, new_name):
+        from integration_bridge import BridgeResult
+
+        return BridgeResult(success=True, native_supported=False, detail="n/a")
+
+    async def remove_native(self, device_data, *, force=False):
+        from integration_bridge import BridgeResult
+
+        return BridgeResult(success=True, native_supported=True, detail="removed")
+
+
+class _RS:
+    async def load_structure(self, ws):
+        pass
+
+
+def _job():
+    return {
+        "job_id": "t1",
+        "state": device_swap.STATE_CONFIRMED,
+        "created": "t",
+        "old_device": {"device_id": "old", "name": "Küche Fenster"},
+        "new_device": {"device_id": "new", "name": "Küche Fenster IKEA"},
+        "target_device_name": "Küche Fenster",
+        "old_device_disposition": device_swap.DISPOSITION_KEEP,
+        "old_device_entities": [
+            "binary_sensor.kuche_fenster_zustand",
+            "sensor.kuche_fenster_batterie",
+        ],
+        "new_device_entities": [
+            "binary_sensor.kuche_fenster_ikea_zustand",
+            "sensor.kuche_fenster_ikea_batterie",
+            "sensor.kuche_fenster_ikea_batterietyp",
+        ],
+        "entity_mapping": [
+            {
+                "old_entity_id": "binary_sensor.kuche_fenster_zustand",
+                "new_entity_id_current": "binary_sensor.kuche_fenster_ikea_zustand",
+                "status": "pending",
+            }
+        ],
+        "steps": {},
+        "log": [],
+    }
+
+
+def _run(tmp_path, job):
+    store = SwapJobStore(str(tmp_path))
+    er = _ER()
+    du = _DU()
+    ex = SwapExecutor(store, _DR(), er, du, _Bridge(), _RS(), states_by_id={}, timestamp="t1")
+    import asyncio
+
+    out = asyncio.run(ex.run(job))
+    return out, er, du
+
+
+def test_executor_completes(tmp_path):
+    out, _, _ = _run(tmp_path, _job())
+    assert out["state"] == device_swap.STATE_COMPLETED
+
+
+def test_executor_frees_old_entities(tmp_path):
+    _, er, _ = _run(tmp_path, _job())
+    freed = [c for c in er.calls if c[1].endswith("_swapout")]
+    assert ("binary_sensor.kuche_fenster_zustand", "binary_sensor.kuche_fenster_zustand_swapout") in freed
+    assert ("sensor.kuche_fenster_batterie", "sensor.kuche_fenster_batterie_swapout") in freed
+
+
+def test_executor_renames_all_new_entities_prefix_swap(tmp_path):
+    _, er, _ = _run(tmp_path, _job())
+    # all three new entities incl. the unmapped batterietyp
+    assert ("binary_sensor.kuche_fenster_ikea_zustand", "binary_sensor.kuche_fenster_zustand") in er.calls
+    assert ("sensor.kuche_fenster_ikea_batterietyp", "sensor.kuche_fenster_batterietyp") in er.calls
+
+
+def test_executor_rewires_deps_to_final_id(tmp_path):
+    _, _, du = _run(tmp_path, _job())
+    # only the in-use mapped pair, rewired to the final (suffix-preserved) id
+    assert du.calls and du.calls[0] == (
+        "binary_sensor.kuche_fenster_zustand",
+        "binary_sensor.kuche_fenster_zustand",
+    )
+
+
+def test_executor_order_free_before_rename(tmp_path):
+    _, er, _ = _run(tmp_path, _job())
+    last_free = max(i for i, c in enumerate(er.calls) if c[1].endswith("_swapout"))
+    first_rename = min(i for i, c in enumerate(er.calls) if "_ikea" in c[0])
+    assert last_free < first_rename
+
+
+def test_executor_idempotent_resume(tmp_path):
+    # run once, then run the same (completed) job again -> no error, stays completed
+    out, _, _ = _run(tmp_path, _job())
+    import asyncio
+
+    store = SwapJobStore(str(tmp_path))
+    ex = SwapExecutor(store, _DR(), _ER(), _DU(), _Bridge(), _RS(), states_by_id={}, timestamp="t2")
+    again = asyncio.run(ex.run(out))
+    assert again["state"] == device_swap.STATE_COMPLETED
+
+
+# --------------------------------------------------------------------------- #
+# SwapJobStore persistence
+# --------------------------------------------------------------------------- #
+
+
+def test_jobstore_save_load_list(tmp_path):
+    store = SwapJobStore(str(tmp_path))
+    store.save({"job_id": "abc", "state": device_swap.STATE_PROPOSED})
+    assert store.load("abc")["state"] == device_swap.STATE_PROPOSED
+    assert any(j["job_id"] == "abc" for j in store.list_unfinished())
+    store.delete("abc")
+    assert store.load("abc") is None

--- a/tests/test_entity_ref_utils.py
+++ b/tests/test_entity_ref_utils.py
@@ -1,0 +1,56 @@
+"""Tests for the central, word-boundary-safe entity reference replacement."""
+
+from entity_ref_utils import (
+    extract_entity_ids,
+    replace_entity_in_obj,
+    replace_entity_ref_in_string,
+)
+
+
+def test_replace_exact_value():
+    assert replace_entity_ref_in_string("light.old", "light.old", "light.new") == ("light.new", True)
+
+
+def test_replace_no_match():
+    assert replace_entity_ref_in_string("light.other", "light.old", "light.new") == ("light.other", False)
+
+
+def test_template_word_boundary_does_not_overmatch():
+    # sensor.temp must NOT match inside sensor.temperature
+    result = replace_entity_ref_in_string("{{ states('sensor.temperature') }}", "sensor.temp", "sensor.x")
+    assert result == ("{{ states('sensor.temperature') }}", False)
+
+
+def test_template_match():
+    value, changed = replace_entity_ref_in_string("{{ states('sensor.temp') }}", "sensor.temp", "sensor.x")
+    assert changed
+    assert "sensor.x" in value
+    assert "sensor.temp'" not in value
+
+
+def test_plain_freetext_is_untouched():
+    # Not a template -> leave plain text alone even if the id appears as a substring
+    result = replace_entity_ref_in_string("The sensor.temp is warm", "sensor.temp", "sensor.x")
+    assert result == ("The sensor.temp is warm", False)
+
+
+def test_replace_in_obj_nested_in_place():
+    data = {"a": "light.old", "b": ["x", "light.old"], "c": {"d": "light.old"}}
+    changed = replace_entity_in_obj(data, "light.old", "light.new")
+    assert changed is True
+    assert data == {"a": "light.new", "b": ["x", "light.new"], "c": {"d": "light.new"}}
+
+
+def test_replace_in_obj_no_change():
+    data = {"a": "light.other"}
+    assert replace_entity_in_obj(data, "light.old", "light.new") is False
+    assert data == {"a": "light.other"}
+
+
+def test_extract_entity_ids_from_dashboard_like_structure():
+    cfg = {
+        "views": [{"cards": [{"type": "entities", "entities": ["sensor.a", {"entity": "light.b"}]}]}],
+        "x": "{{ states('sensor.c') }}",
+    }
+    ids = extract_entity_ids(cfg)
+    assert {"sensor.a", "light.b", "sensor.c"} <= ids

--- a/tests/test_integration_bridge.py
+++ b/tests/test_integration_bridge.py
@@ -1,0 +1,77 @@
+"""Tests for the integration bridge: integration/IEEE extraction and adapter selection."""
+
+import asyncio
+
+from bridge_adapters import build_bridge
+from bridge_mqtt_adapter import MqttZ2MAdapter
+from integration_bridge import (
+    extract_config_entry_id,
+    extract_integrations,
+    extract_z2m_ieee,
+)
+
+
+def test_extract_integrations():
+    dev = {"identifiers": [["mqtt", "zigbee2mqtt_0xabc"], ["matter", "serial_x"]]}
+    assert set(extract_integrations(dev)) == {"mqtt", "matter"}
+
+
+def test_extract_integrations_strips_colon_domain():
+    dev = {"identifiers": [["homekit_controller:accessory-id", "x"]]}
+    assert extract_integrations(dev) == ["homekit_controller"]
+
+
+def test_extract_z2m_ieee():
+    assert extract_z2m_ieee({"identifiers": [["mqtt", "zigbee2mqtt_0x001788010cd81c13"]]}) == "0x001788010cd81c13"
+
+
+def test_extract_z2m_ieee_ignores_non_z2m_and_bridge():
+    assert extract_z2m_ieee({"identifiers": [["mqtt", "[301DEEE4]"]]}) is None
+    assert extract_z2m_ieee({"identifiers": [["mqtt", "zigbee2mqtt_bridge_0x84b4"]]}) is None
+    assert extract_z2m_ieee({"identifiers": [["matter", "serial_x"]]}) is None
+
+
+def test_extract_config_entry_id():
+    assert extract_config_entry_id({"config_entries": ["01ABC"]}) == "01ABC"
+    assert extract_config_entry_id({"config_entries": []}) is None
+
+
+class _DR:
+    def __init__(self):
+        self.calls = []
+
+    async def remove_config_entry(self, device_id, config_entry_id):
+        self.calls.append((device_id, config_entry_id))
+        return {"success": True}
+
+
+def test_build_bridge_without_mqtt_has_no_z2m_adapter():
+    bridge = build_bridge(_DR(), mqtt_bridge=None)
+    assert not any(isinstance(a, MqttZ2MAdapter) for a in bridge._adapters)
+
+
+def test_adapter_selection():
+    bridge = build_bridge(_DR(), mqtt_bridge=object())
+    z2m = {"identifiers": [["mqtt", "zigbee2mqtt_0x00158d0001abcdef"]]}
+    other_mqtt = {"identifiers": [["mqtt", "[301DEEE4]"]]}
+    matter = {"identifiers": [["matter", "serial_x"]]}
+    assert type(bridge.select_adapter(z2m)).__name__ == "MqttZ2MAdapter"
+    assert type(bridge.select_adapter(other_mqtt)).__name__ == "RegistryAdapter"
+    assert type(bridge.select_adapter(matter)).__name__ == "MatterAdapter"
+
+
+def test_registry_remove_native_uses_device_id_key():
+    dr = _DR()
+    bridge = build_bridge(dr, mqtt_bridge=None)
+    snap = {"device_id": "fe443", "integrations": ["matter"], "config_entries": ["01ABC"]}
+    res = asyncio.run(bridge.remove_native(snap, force=True))
+    assert res.success
+    assert dr.calls == [("fe443", "01ABC")]
+
+
+def test_registry_remove_native_missing_device_id():
+    dr = _DR()
+    bridge = build_bridge(dr, mqtt_bridge=None)
+    res = asyncio.run(bridge.remove_native({"config_entries": ["01ABC"]}, force=True))
+    assert not res.success
+    assert dr.calls == []

--- a/tests/test_lovelace_updater.py
+++ b/tests/test_lovelace_updater.py
@@ -1,0 +1,86 @@
+"""Tests for the Lovelace updater (storage rewrite, YAML scan) with a mock WebSocket."""
+
+import asyncio
+import copy
+
+from lovelace_updater import LovelaceUpdater
+
+
+class MockWS:
+    """Minimal HA WebSocket mock implementing the lovelace/* commands."""
+
+    def __init__(self, dashboards, configs, yaml_paths=None):
+        self._dashboards = dashboards
+        self._cfgs = configs
+        self._yaml = set(yaml_paths or [])  # url_paths where save fails (yaml mode)
+        self._id = 0
+        self._queue = []
+
+    async def _send_message(self, msg):
+        self._id += 1
+        t = msg["type"]
+        if t == "lovelace/dashboards/list":
+            self._queue.append({"id": self._id, "success": True, "result": self._dashboards})
+        elif t == "lovelace/config":
+            cfg = self._cfgs.get(msg.get("url_path"))
+            self._queue.append({"id": self._id, "success": True, "result": copy.deepcopy(cfg)})
+        elif t == "lovelace/config/save":
+            up = msg.get("url_path")
+            if up in self._yaml or up is None and None in self._yaml:
+                self._queue.append({"id": self._id, "success": False, "error": "yaml mode"})
+            else:
+                self._cfgs[up] = msg["config"]
+                self._queue.append({"id": self._id, "success": True})
+        return self._id
+
+    async def _receive_message(self):
+        return self._queue.pop(0)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_update_all_dashboards_storage_only():
+    ws = MockWS(
+        dashboards=[{"url_path": "storage1", "mode": "storage"}, {"url_path": "yaml1", "mode": "yaml"}],
+        configs={
+            None: {"cards": [{"entity": "sensor.old"}]},
+            "storage1": {"cards": [{"entity": "sensor.old"}]},
+            "yaml1": {"cards": [{"entity": "sensor.old"}]},
+        },
+    )
+    lu = LovelaceUpdater(ws)
+    changed = _run(lu.update_all_dashboards("sensor.old", "sensor.new"))
+    # only storage-mode targets (default + storage1) are written; yaml1 is skipped
+    assert "storage1" in changed
+    assert "yaml1" not in changed
+
+
+def test_scan_renames_finds_yaml_only():
+    # storage already rewritten -> only yaml dashboards still contain the old id
+    ws = MockWS(
+        dashboards=[{"url_path": "storage1", "mode": "storage"}, {"url_path": "yaml1", "mode": "yaml"}],
+        configs={
+            None: {"cards": [{"entity": "sensor.new"}]},  # already updated
+            "storage1": {"cards": [{"entity": "sensor.new"}]},  # already updated
+            "yaml1": {"cards": [{"entity": "sensor.old"}]},  # still old (not writable)
+        },
+    )
+    lu = LovelaceUpdater(ws)
+    manual = _run(lu.scan_renames([("sensor.old", "sensor.new")]))
+    dboards = sorted(m["dashboard"] for m in manual)
+    assert dboards == ["yaml1"]
+
+
+def test_get_referenced_entity_ids_includes_yaml():
+    ws = MockWS(
+        dashboards=[{"url_path": "yaml1", "mode": "yaml"}],
+        configs={
+            None: {"cards": [{"entity": "sensor.a"}]},
+            "yaml1": {"cards": [{"entity": "sensor.b"}]},
+        },
+    )
+    lu = LovelaceUpdater(ws)
+    refs = _run(lu.get_referenced_entity_ids())
+    assert {"sensor.a", "sensor.b"} <= refs

--- a/tests/test_mqtt_credentials.py
+++ b/tests/test_mqtt_credentials.py
@@ -1,0 +1,74 @@
+"""Tests for fetching MQTT credentials from the Supervisor (graceful degradation)."""
+
+import asyncio
+
+import aiohttp
+
+import mqtt_credentials
+
+
+class _FakeResp:
+    def __init__(self, status, data):
+        self.status = status
+        self._data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self):
+        return self._data
+
+
+class _FakeSession:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def get(self, url, headers=None):
+        return self._resp
+
+
+def _patch(monkeypatch, status, data):
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "tok")
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: _FakeSession(_FakeResp(status, data)))
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_credentials_ok(monkeypatch):
+    _patch(
+        monkeypatch,
+        200,
+        {
+            "result": "ok",
+            "data": {"host": "core-mosquitto", "port": 1883, "ssl": False, "username": "addons", "password": "pw"},
+        },
+    )
+    creds = _run(mqtt_credentials.get_mqtt_credentials())
+    assert creds == {"host": "core-mosquitto", "port": 1883, "username": "addons", "password": "pw", "ssl": False}
+
+
+def test_credentials_403_returns_none(monkeypatch):
+    _patch(monkeypatch, 403, {"result": "error"})
+    assert _run(mqtt_credentials.get_mqtt_credentials()) is None
+
+
+def test_credentials_no_host_returns_none(monkeypatch):
+    _patch(monkeypatch, 200, {"result": "ok", "data": {}})
+    assert _run(mqtt_credentials.get_mqtt_credentials()) is None
+
+
+def test_credentials_no_token_returns_none(monkeypatch):
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    monkeypatch.delenv("HA_TOKEN", raising=False)
+    assert _run(mqtt_credentials.get_mqtt_credentials()) is None


### PR DESCRIPTION
Closes #45

## Description
Professionalizes the repo: GitHub templates, CONTRIBUTING (branch model + parallel-work via worktrees), a pytest suite (44 offline tests), CI `test`/`frontend` jobs, issue/PR governance automation, a pre-commit hook mirroring CI, and Renovate automerge gating. README name without "(Beta)".

`next-release` was fast-forwarded to main beforehand, so this branches off the current state.

> Note: Issue/PR templates + governance workflows take effect once merged to the default branch (`main`).

## Type of change
- [x] 📝 Documentation / chore

## Checklist
- [x] Targets `next-release`
- [x] Lint passes (flake8/black/isort) + 44 pytest tests green
- [x] JSON/YAML validated locally
- [x] Log messages in English

## How was this tested?
`pytest` (44 passed), full-repo flake8/black/isort, YAML/JSON validation of all workflows/templates, worktree-helper syntax + slugify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)