### PR TITLE
ci+renovate: Claude PR review workflow, assign Renovate PRs to Skjall, exempt maintainers from issue requirement

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,42 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Run on every PR, or when someone writes "@claude" in a comment.
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review the changes in this pull request. Focus on:
+            - Correctness bugs and regressions
+            - Security concerns (this add-on talks to Home Assistant via tokens/WebSocket)
+            - Adherence to the repo conventions in CLAUDE.md (type hints, docstrings,
+              Black 120-char line length, English log messages)
+            Post concise inline comments on the specific lines that need attention.
+            Skip nitpicks; only raise findings worth acting on.
+          # Swap to claude-opus-4-8 for deeper reviews at higher quota cost.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 10

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -1,7 +1,9 @@
 name: PR linked issue
 
-# Every PR must reference an issue (Closes/Fixes/Resolves #N). Otherwise it gets
-# a "needs issue" label and a failing check until an issue is linked.
+# Contributor PRs must reference an issue (Closes/Fixes/Resolves #N). Otherwise
+# they get a "needs issue" label and a failing check until an issue is linked.
+# Bots (Renovate/Dependabot) and maintainers (owner/members/collaborators) are
+# exempt — they don't need to file an issue for their own changes.
 
 on:
   pull_request_target:
@@ -25,6 +27,15 @@ jobs:
             // tracked centrally via the dependency dashboard.
             if (pr.user.type === "Bot" || /\[bot\]$/.test(pr.user.login) || pr.user.login === "renovate-bot") {
               core.info(`Bot PR by ${pr.user.login} — skipping linked-issue check`);
+              return;
+            }
+
+            // Maintainer PRs (repo owner, org members, collaborators) are exempt.
+            // External contributors (CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE)
+            // must still link an issue.
+            const MAINTAINER = ["OWNER", "MEMBER", "COLLABORATOR"];
+            if (MAINTAINER.includes(pr.author_association)) {
+              core.info(`Maintainer PR (${pr.author_association}) by ${pr.user.login} — skipping linked-issue check`);
               return;
             }
 

--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,9 @@
     "dependencies",
     "type: chore"
   ],
+  "assignees": [
+    "Skjall"
+  ],
   "reviewers": [
     "Skjall"
   ]


### PR DESCRIPTION
Part of the repo professionalization (#45). Maintainer PR — no linked issue required once commit 3 lands.

## Changes

1. **renovate.json** — `assignees: ["Skjall"]` so Renovate PRs are assigned to you, not only review-requested.
2. **.github/workflows/claude-review.yml** — new workflow: `anthropics/claude-code-action@v1` reviews every PR and responds to `@claude` mentions. Authenticated via `CLAUDE_CODE_OAUTH_TOKEN` (Claude Max subscription, **no** API key); needs `id-token: write` for the OAuth/OIDC exchange. Activates once the file is on the default branch (`main`).
3. **.github/workflows/pr-linked-issue.yml** — maintainer exemption: only external contributors must link an issue; owner/members/collaborators (and bots) are exempt.

## Merge note

`pr-linked-issue` runs via `pull_request_target` using the rule version on `main`. The `check` therefore fails **once** on this PR (the old rule without the maintainer exemption). Merge via **admin override** — afterwards the exemption applies automatically to all future maintainer PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)