### PR TITLE
ci: skip Claude review on bot PRs + self-heal stale needs-issue label

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,10 +15,12 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Run on every PR, or when someone writes "@claude" in a comment.
+    # Run on every human PR, or when a human writes "@claude" in a comment.
+    # Skip bot-initiated events (e.g. Renovate): the action refuses bot actors,
+    # and dependency bumps don't need an AI review.
     if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+      (github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot') ||
+      (github.event_name == 'issue_comment' && github.event.comment.user.type != 'Bot' && contains(github.event.comment.body, '@claude'))
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -22,11 +22,24 @@ jobs:
           script: |
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
             const pr = context.payload.pull_request;
+            const LABEL = "needs issue";
+
+            // Remove a stale "needs issue" label if one is present (self-healing
+            // for PRs labelled before an exemption applied, e.g. older bot PRs).
+            const clearLabel = async () => {
+              const labels = (
+                await github.rest.issues.listLabelsOnIssue({ ...repo, issue_number: pr.number })
+              ).data.map((l) => l.name);
+              if (labels.includes(LABEL)) {
+                await github.rest.issues.removeLabel({ ...repo, issue_number: pr.number, name: LABEL }).catch(() => {});
+              }
+            };
 
             // Bot PRs (Renovate / Dependabot) don't need a linked issue — they are
             // tracked centrally via the dependency dashboard.
             if (pr.user.type === "Bot" || /\[bot\]$/.test(pr.user.login) || pr.user.login === "renovate-bot") {
               core.info(`Bot PR by ${pr.user.login} — skipping linked-issue check`);
+              await clearLabel();
               return;
             }
 
@@ -36,13 +49,13 @@ jobs:
             const MAINTAINER = ["OWNER", "MEMBER", "COLLABORATOR"];
             if (MAINTAINER.includes(pr.author_association)) {
               core.info(`Maintainer PR (${pr.author_association}) by ${pr.user.login} — skipping linked-issue check`);
+              await clearLabel();
               return;
             }
 
             const body = pr.body || "";
             const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i;
             const linked = re.test(body);
-            const LABEL = "needs issue";
 
             const labels = (
               await github.rest.issues.listLabelsOnIssue({ ...repo, issue_number: pr.number })


### PR DESCRIPTION
Maintainer PR.

## Problem

1. The Claude review workflow failed on every Renovate PR with:
   `Workflow initiated by non-human actor: renovate (type: Bot)` (exit 1).
   The `claude-code-action` refuses bot actors by default.
2. Renovate PRs opened before the bot exemption landed (#50) kept a stale
   `needs issue` label that the exemption path never cleaned up.

## Fix

1. **claude-review.yml** — skip bot-initiated events (`pull_request.user.type == 'Bot'`,
   and bot-authored `@claude` comments). Dependency bumps don't need an AI review,
   and this avoids the bot-actor error entirely.
2. **pr-linked-issue.yml** — the bot and maintainer exemption branches now remove an
   existing `needs issue` label, so previously mislabelled PRs heal on their next event.

Stale labels on #41/#40/#51 were already removed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)