### PR TITLE
ci+renovate: route review requests to maintainer only where needed

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,0 +1,51 @@
+name: Request review
+
+# Request the maintainer's review only on external contributor PRs. Routine
+# Renovate PRs that auto-merge don't ping anyone (Renovate requests reviews
+# itself only on majors / frontend deps, via renovate.json). Maintainer and
+# bot PRs are skipped here.
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const pr = context.payload.pull_request;
+            const REVIEWER = "skjall";
+
+            // Bots (Renovate/Dependabot) handle their own review routing.
+            if (pr.user.type === "Bot" || /\[bot\]$/.test(pr.user.login)) {
+              core.info(`Bot PR by ${pr.user.login} — no review request`);
+              return;
+            }
+
+            // Maintainers (owner/members/collaborators) don't need a review
+            // request for their own changes; only external contributors do.
+            const MAINTAINER = ["OWNER", "MEMBER", "COLLABORATOR"];
+            if (MAINTAINER.includes(pr.author_association)) {
+              core.info(`Maintainer PR (${pr.author_association}) by ${pr.user.login} — no review request`);
+              return;
+            }
+
+            // GitHub cannot request a review from the PR author.
+            if (pr.user.login === REVIEWER) {
+              core.info(`PR authored by the reviewer — skipping`);
+              return;
+            }
+
+            await github.rest.pulls.requestReviewers({
+              ...repo,
+              pull_number: pr.number,
+              reviewers: [REVIEWER],
+            });
+            core.info(`Requested review from ${REVIEWER} on contributor PR #${pr.number}`);

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
       "groupName": "Build dependencies"
     },
     {
-      "description": "Auto-merge low-risk updates once CI is green (requires branch protection on main)",
+      "description": "Auto-merge low-risk updates once CI is green; no review request needed",
       "matchUpdateTypes": [
         "minor",
         "patch",
@@ -54,11 +54,27 @@
       "platformAutomerge": true
     },
     {
-      "description": "Never auto-merge major updates — review manually",
+      "description": "Major updates: never auto-merge, request review",
       "matchUpdateTypes": [
         "major"
       ],
-      "automerge": false
+      "automerge": false,
+      "reviewers": [
+        "Skjall"
+      ]
+    },
+    {
+      "description": "Frontend deps (npm) can change the rendered UI: never auto-merge, request review, gated by the visual-regression check",
+      "matchManagers": [
+        "npm"
+      ],
+      "automerge": false,
+      "addLabels": [
+        "frontend"
+      ],
+      "reviewers": [
+        "Skjall"
+      ]
     }
   ],
   "vulnerabilityAlerts": {
@@ -71,9 +87,6 @@
     "type: chore"
   ],
   "assignees": [
-    "Skjall"
-  ],
-  "reviewers": [
     "Skjall"
   ]
 }


### PR DESCRIPTION
Maintainer PR.

## Why

Routine Renovate PRs (backend/python minor+patch) auto-merge and don't need anyone's attention — but they were requesting the maintainer's review on every PR. This stops that noise and routes review requests only to the cases that actually need eyes.

## Review requests after this

| PR type | Auto-merge | Review requested? |
|---|---|---|
| Renovate backend minor/patch | yes | no |
| Renovate **major** (any) | no | **yes** (Skjall) |
| Renovate **frontend** (npm) | no | **yes** (Skjall) + `frontend` label |
| External **contributor** PR | n/a | **yes** (Skjall) |
| Maintainer / bot PR | — | no |

## Changes

- **renovate.json** — drop blanket top-level `reviewers`. Add `reviewers: [Skjall]` to the major rule and to a new npm/frontend rule. Frontend (npm) deps also get `automerge: false` (they can change the rendered UI) and a `frontend` label. Backend/python minor+patch keep auto-merging silently.
- **request-review.yml** — new workflow: requests Skjall's review on external contributor PRs only (skips bots and maintainers).

Frontend deps will additionally be gated by the visual-regression check (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)