### PR TITLE
chore: drop beta warnings (go stable 1.x)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,8 +5,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug! This add-on is **beta software** —
-        please include as much detail as possible so we can reproduce the issue.
+        Thanks for taking the time to report a bug!
+        Please include as much detail as possible so we can reproduce the issue.
   - type: checkboxes
     id: preflight
     attributes:
@@ -20,8 +20,8 @@ body:
     id: addon-version
     attributes:
       label: Add-on version
-      description: See Settings → Add-ons → Entity Manager (e.g. 1.0.3-beta)
-      placeholder: "1.0.3-beta"
+      description: See Settings → Add-ons → Entity Manager (e.g. 1.0.3)
+      placeholder: "1.0.3"
     validations:
       required: true
   - type: input

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving the **Home Assistant Entity Manager** add-
 This document describes the branching model, how to set up a development environment,
 and the conventions we follow.
 
-> This add-on is **beta software**. Contributions, bug reports and ideas are very welcome.
+> Contributions, bug reports and ideas are very welcome.
 
 ## Branching model (GitHub Flow)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Home Assistant Entity Manager Add-on
 
-[![Beta](https://img.shields.io/badge/Status-Beta-orange.svg)](https://github.com/Skjall/home-assistant-entity-manager)
 [![GitHub Release](https://img.shields.io/github/release/Skjall/home-assistant-entity-manager.svg?style=flat-square)](https://github.com/Skjall/home-assistant-entity-manager/releases)
 [![License](https://img.shields.io/github/license/Skjall/home-assistant-entity-manager.svg?style=flat-square)](LICENSE)
 
 A Home Assistant Add-on for standardizing and managing entity names according to a consistent, logical naming convention with an integrated Web UI.
-
-> **⚠️ BETA SOFTWARE**: This Add-on is under active development and may still have bugs. Use with caution and test before relying on it in production. Please report any issues on the [GitHub Issues](https://github.com/Skjall/home-assistant-entity-manager/issues) page.
 
 ## Features
 

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "name": "Entity Manager",
   "version": "1.0.3-beta",
   "slug": "entity_manager",
-  "description": "⚠️ BETA VERSION - USE WITH CAUTION ⚠️ Manage and standardize Home Assistant entity names",
+  "description": "Manage and standardize Home Assistant entity names",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
   "boot": "auto",

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Entity Manager Add-ons (Beta)",
+  "name": "Entity Manager Add-ons",
   "url": "https://github.com/Skjall/home-assistant-entity-manager",
   "maintainer": "Skjall"
 }

--- a/run.sh
+++ b/run.sh
@@ -7,8 +7,6 @@ export ENABLE_Z2M_BRIDGE=$(bashio::config 'enable_z2m_bridge' || echo 'true')
 export Z2M_BASE_TOPIC=$(bashio::config 'z2m_base_topic' || echo 'zigbee2mqtt')
 
 bashio::log.info "Starting Entity Manager..."
-bashio::log.warning "⚠️ BETA VERSION - This add-on is under active development!"
-bashio::log.warning "⚠️ Use with caution - Test before relying on it in production!"
 
 # Set environment variables
 export HA_URL="http://supervisor/core"

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,5 +1,5 @@
 {
-  "title": "Entitäts-Manager (Beta)",
+  "title": "Entitäts-Manager",
   "description": "Verwalten und standardisieren Sie Home Assistant Entitäts-Namen",
   "configuration": {
     "log_level": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "title": "Entity Manager (Beta)",
+  "title": "Entity Manager",
   "description": "Manage and standardize Home Assistant entity names",
   "configuration": {
     "log_level": {

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,5 +1,5 @@
 {
-  "title": "Gestor de Entidades (Beta)",
+  "title": "Gestor de Entidades",
   "description": "Gestionar y estandarizar nombres de entidades de Home Assistant",
   "configuration": {
     "log_level": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,5 +1,5 @@
 {
-  "title": "Gestionnaire d'entités (Beta)",
+  "title": "Gestionnaire d'entités",
   "description": "Gérer et standardiser les noms des entités Home Assistant",
   "configuration": {
     "log_level": {

--- a/translations/ui/de.json
+++ b/translations/ui/de.json
@@ -1,9 +1,6 @@
 {
   "header": {
     "title": "Entitäts-Manager",
-    "version_badge": "BETA",
-    "warning_banner": "BETA VERSION - MIT VORSICHT VERWENDEN",
-    "warning_description": "Mit Vorsicht verwenden! Dieses Add-on befindet sich in aktiver Entwicklung und kann noch Probleme verursachen.",
     "settings": "Einstellungen"
   },
   "panels": {

--- a/translations/ui/en.json
+++ b/translations/ui/en.json
@@ -1,9 +1,6 @@
 {
   "header": {
     "title": "Entity Manager",
-    "version_badge": "BETA",
-    "warning_banner": "BETA VERSION - USE WITH CAUTION",
-    "warning_description": "Use with caution! This add-on is under active development and may still have issues.",
     "settings": "Settings"
   },
   "panels": {

--- a/translations/ui/es.json
+++ b/translations/ui/es.json
@@ -1,9 +1,6 @@
 {
   "header": {
     "title": "Gestor de Entidades",
-    "version_badge": "BETA",
-    "warning_banner": "VERSIÓN BETA - USAR CON PRECAUCIÓN",
-    "warning_description": "¡Usar con precaución! Este complemento está en desarrollo activo y aún puede causar problemas.",
     "settings": "Configuración"
   },
   "panels": {

--- a/translations/ui/fr.json
+++ b/translations/ui/fr.json
@@ -1,9 +1,6 @@
 {
   "header": {
     "title": "Gestionnaire d'entités",
-    "version_badge": "BETA",
-    "warning_banner": "VERSION BÊTA - À UTILISER AVEC PRUDENCE",
-    "warning_description": "À utiliser avec prudence ! Ce module complémentaire est en développement actif et peut encore causer des problèmes.",
     "settings": "Paramètres"
   },
   "panels": {

--- a/web_ui.py
+++ b/web_ui.py
@@ -214,7 +214,6 @@ async def init_client():
         # In Add-on mode, use Supervisor API
         base_url = os.getenv("HA_URL", "http://supervisor/core")
         token = os.getenv("HA_TOKEN", os.getenv("SUPERVISOR_TOKEN"))
-        logger.info("BETA VERSION - Entity Manager Add-on")
         logger.info(f"Connecting to Home Assistant at {base_url}")
         renamer_state["client"] = HomeAssistantClient(base_url, token)
         renamer_state["restructurer"] = EntityRestructurer(
@@ -3106,7 +3105,6 @@ if __name__ == "__main__":
 
     # In Add-on mode, use port 5000 for Ingress
     port = int(os.getenv("WEB_UI_PORT", 5000))
-    print("\nBETA VERSION - Entity Manager Add-on")
     print(f"\nStarting Web UI on port {port}\n")
 
     # Run without debug in production


### PR DESCRIPTION
Maintainer PR. The go-stable copy cleanup flagged in #63 — removes beta messaging now that we ship stable 1.x.

## Removed
- **config.json** description "⚠️ BETA VERSION …" prefix
- **repository.json** name "… (Beta)"
- **run.sh** beta startup warnings
- **web_ui.py** "BETA VERSION" startup log lines (2×)
- **README** beta badge + "⚠️ BETA SOFTWARE" blockquote
- **CONTRIBUTING** intro "beta software" note
- **bug_report.yml** beta wording + version placeholder (`1.0.3-beta` → `1.0.3`)
- **translations**: localized titles "… (Beta)" → "…" (de/en/es/fr) and the orphaned `header.version_badge` / `warning_banner` / `warning_description` keys (verified unreferenced anywhere in the UI)

## Not here
- The `config.json` **version** bump (`1.0.3-beta` → `1.0.3`) lands via the release-automation PR (#63) to avoid editing the same line in two PRs.
- `release.yml`'s `beta`-prerelease check goes away with #63 (which removes that workflow).

Touches different hunks than #63 → no conflict; with auto-merge enabled they cascade in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)