### PR TITLE
ci(claude-review): raise max-turns to 100

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,4 +43,4 @@ jobs:
           # Swap to claude-opus-4-8 for deeper reviews at higher quota cost.
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 25
+            --max-turns 100


### PR DESCRIPTION
The Claude review failed on #66 with 'Reached maximum number of turns (25)' on the large diff. Raise --max-turns 25 -> 100 so reviews complete. CI/tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)