### PR TITLE
feat(swap): carry over device area and entity settings

### DIFF
--- a/device_swap.py
+++ b/device_swap.py
@@ -33,6 +33,7 @@ STATE_CONFIRMED = "CONFIRMED"
 STATE_FREEING_OLD_NAME = "FREEING_OLD_NAME"
 STATE_RENAMING_NEW_DEVICE = "RENAMING_NEW_DEVICE"
 STATE_RENAMING_ENTITIES = "RENAMING_ENTITIES"
+STATE_TRANSFERRING_SETTINGS = "TRANSFERRING_SETTINGS"
 STATE_UPDATING_DEPENDENCIES = "UPDATING_DEPENDENCIES"
 STATE_DISPOSING_OLD_DEVICE = "DISPOSING_OLD_DEVICE"
 STATE_NATIVE_REMOVE = "NATIVE_REMOVE"
@@ -45,6 +46,7 @@ EXECUTION_SEQUENCE = [
     STATE_FREEING_OLD_NAME,
     STATE_RENAMING_NEW_DEVICE,
     STATE_RENAMING_ENTITIES,
+    STATE_TRANSFERRING_SETTINGS,
     STATE_UPDATING_DEPENDENCIES,
     STATE_DISPOSING_OLD_DEVICE,
     STATE_NATIVE_REMOVE,
@@ -289,6 +291,7 @@ class SwapExecutor:
             STATE_FREEING_OLD_NAME: self._free_old_name,
             STATE_RENAMING_NEW_DEVICE: self._rename_new_device,
             STATE_RENAMING_ENTITIES: self._rename_entities,
+            STATE_TRANSFERRING_SETTINGS: self._transfer_settings,
             STATE_UPDATING_DEPENDENCIES: self._update_dependencies,
             STATE_DISPOSING_OLD_DEVICE: self._dispose_old_device,
             STATE_NATIVE_REMOVE: self._native_remove,
@@ -355,6 +358,14 @@ class SwapExecutor:
         await self.device_registry.rename_device(new["device_id"], target)
         self._log(job, STATE_RENAMING_NEW_DEVICE, f"New device renamed to '{target}'")
 
+        # Assign the new device to the old device's area, so it lands where the old
+        # one was. Entities that inherit their area from the device follow automatically.
+        old_area_id = (job.get("old_device") or {}).get("area_id")
+        if old_area_id and not job.get("area_assigned"):
+            await self.device_registry.assign_area(new["device_id"], old_area_id)
+            job["area_assigned"] = True
+            self._log(job, STATE_RENAMING_NEW_DEVICE, f"New device assigned to area '{old_area_id}'")
+
         # Z2M-friendly_name angleichen (nur bei Z2M-Geräten; nicht fatal).
         if self.bridge is not None:
             try:
@@ -419,6 +430,54 @@ class SwapExecutor:
             return None
         basename = cur[len(old_dev_name) :].strip()
         return f"{target_name} {basename}".strip() if basename else target_name
+
+    async def _transfer_settings(self, job: Dict[str, Any]) -> None:
+        """Copy the old entities' user settings onto the matching new entities.
+
+        Transferred (only where Home Assistant supports it): icon, device_class
+        ("display as"), entity_category, entity area override and the user-set
+        hidden/disabled flags. The entity area is copied verbatim - ``None`` means
+        "use the device area", which now points at the old device's area (assigned in
+        RENAMING_NEW_DEVICE). Pairing uses the full auto-mapping, with the user's
+        confirmed in-use mapping taking precedence. Pro-entity idempotent (Resume).
+        """
+        props_by_old = job.get("old_entity_props") or {}
+        if not props_by_old:
+            return  # nothing captured (e.g. job created before this feature)
+
+        # Pairing old -> new: start from the full auto-mapping, let confirmed pairs win.
+        pairing = dict(job.get("property_pairs") or {})
+        for pair in job.get("entity_mapping", []):
+            pairing[pair["old_entity_id"]] = pair["new_entity_id_current"]
+
+        renamed = job.get("new_renamed", {})
+        done = job.setdefault("settings_transferred", {})
+        for old_id, new_current in pairing.items():
+            if new_current in done:
+                continue  # idempotent (Resume)
+            props = props_by_old.get(old_id)
+            if not props:
+                done[new_current] = None
+                continue
+
+            final_id = renamed.get(new_current, new_current)
+            kwargs: Dict[str, Any] = {"area_id": props.get("area_id")}
+            if props.get("icon"):
+                kwargs["icon"] = props["icon"]
+            if props.get("device_class"):
+                kwargs["device_class"] = props["device_class"]
+            if props.get("entity_category"):
+                kwargs["entity_category"] = props["entity_category"]
+            # Only replicate user-level hide/disable; never touch integration-forced state.
+            if props.get("hidden_by") == "user":
+                kwargs["hidden_by"] = "user"
+            if props.get("disabled_by") == "user":
+                kwargs["disabled_by"] = "user"
+
+            await self.entity_registry.update_entity(final_id, **kwargs)
+            done[new_current] = final_id
+            self._log(job, STATE_TRANSFERRING_SETTINGS, f"Transferred settings {old_id} -> {final_id}")
+            self._persist(job)
 
     async def _update_dependencies(self, job: Dict[str, Any]) -> None:
         """Referenzen umbiegen: ursprüngliche alte ID -> finale neue ID (pro Paar idempotent)."""

--- a/entity_registry.py
+++ b/entity_registry.py
@@ -6,6 +6,11 @@ from label_registry import LabelRegistry
 
 logger = logging.getLogger(__name__)
 
+# Sentinel to distinguish "caller did not pass this field" from "caller explicitly
+# passed None" (which is a meaningful value for area_id/hidden_by/etc. - it clears
+# the override / restores the default).
+_UNSET = object()
+
 
 class EntityRegistry:
     # Optional shared audit log for entity_id renames. Set once by the web app
@@ -38,7 +43,20 @@ class EntityRegistry:
         labels: Optional[List[str]] = None,
         disabled_by: Optional[str] = None,
         enable: bool = False,
+        icon: Any = _UNSET,
+        area_id: Any = _UNSET,
+        hidden_by: Any = _UNSET,
+        entity_category: Any = _UNSET,
+        device_class: Any = _UNSET,
     ) -> Dict[str, Any]:
+        """Update an entity registry entry.
+
+        Home Assistant's ``config/entity_registry/update`` command accepts the user
+        overrides icon, area_id, hidden_by, entity_category and device_class in
+        addition to name/new_entity_id/labels/disabled_by. For the override fields a
+        sentinel (``_UNSET``) is used so that an explicit ``None`` (which clears the
+        override / restores the default) can be told apart from "leave untouched".
+        """
         message = {"type": "config/entity_registry/update", "entity_id": entity_id}
 
         if new_entity_id:
@@ -52,6 +70,16 @@ class EntityRegistry:
             message["disabled_by"] = None
         elif disabled_by is not None:
             message["disabled_by"] = disabled_by
+        if icon is not _UNSET:
+            message["icon"] = icon
+        if area_id is not _UNSET:
+            message["area_id"] = area_id
+        if hidden_by is not _UNSET:
+            message["hidden_by"] = hidden_by
+        if entity_category is not _UNSET:
+            message["entity_category"] = entity_category
+        if device_class is not _UNSET:
+            message["device_class"] = device_class
 
         # Log the message we're sending for debugging
         logger.info(f"Sending entity update message: {message}")
@@ -64,6 +92,26 @@ class EntityRegistry:
 
         if not response.get("success"):
             raise Exception(f"Failed to update entity {entity_id}: {response}")
+
+        return response.get("result", {})
+
+    async def get_entity(self, entity_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch the extended registry entry for a single entity.
+
+        Unlike ``config/entity_registry/list`` (partial entries), the ``get`` command
+        returns the full entry including the user ``device_class`` override, which is
+        needed when copying an entity's settings during a device swap. Returns None if
+        the entity is unknown.
+        """
+        msg_id = await self.ws._send_message({"type": "config/entity_registry/get", "entity_id": entity_id})
+
+        response = await self.ws._receive_message()
+        while response.get("id") != msg_id:
+            response = await self.ws._receive_message()
+
+        if not response.get("success"):
+            logger.warning(f"Could not get entity {entity_id}: {response}")
+            return None
 
         return response.get("result", {})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2342,23 +2342,28 @@
                         <div class="space-y-2">
                             <template x-for="row in swap.mapping" :key="row.old_entity_id">
                                 <div class="rounded-lg border border-gray-200 p-3 transition hover:bg-gray-50" :class="!row.new_entity_id ? 'opacity-60' : ''">
-                                    <div class="flex items-center gap-3">
-                                        <div class="flex-1 min-w-0">
-                                            <p class="font-mono text-xs text-gray-700 truncate" :title="row.old_entity_id" x-text="row.old_entity_id"></p>
-                                            <div class="flex items-center gap-1.5 mt-1.5">
-                                                <span x-show="row.device_class" class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 font-medium" x-text="row.device_class"></span>
-                                            </div>
-                                        </div>
-                                        <div class="w-7 h-7 rounded-full bg-blue-50 flex items-center justify-center shrink-0"><i class="ri-arrow-right-line text-blue-500"></i></div>
-                                        <div class="flex-1 min-w-0">
-                                            <select @change="row.new_entity_id = $event.target.value" class="area-select w-full">
-                                                <option value="" :selected="!row.new_entity_id">— nicht übertragen —</option>
-                                                <template x-for="opt in swapMappingOptions(row)" :key="opt">
-                                                    <option :value="opt" :selected="opt === row.new_entity_id" x-text="opt"></option>
-                                                </template>
-                                            </select>
-                                        </div>
+                                    <!-- Alt: eigenes Feld, volle Breite, umbrechend statt abgeschnitten -->
+                                    <div class="flex items-center justify-between mb-1">
+                                        <span class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Alt</span>
+                                        <span x-show="row.device_class" class="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 font-medium" x-text="row.device_class"></span>
                                     </div>
+                                    <div class="w-full rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1.5 font-mono text-xs break-all leading-snug" :title="row.old_entity_id">
+                                        <span class="text-gray-400" x-text="row.old_entity_id.split('.')[0] + '.'"></span><span class="text-gray-800 font-medium" x-text="row.old_entity_id.split('.').slice(1).join('.')"></span>
+                                    </div>
+                                    <!-- Pfeil zentriert zwischen den beiden gleich breiten Feldern -->
+                                    <div class="flex justify-center text-gray-300 my-1">
+                                        <i class="ri-arrow-down-line text-sm"></i>
+                                    </div>
+                                    <!-- Neu: gleiches Feld-Layout (identisches Padding -> Text fluchtet mit Alt) -->
+                                    <div class="mb-1">
+                                        <span class="text-[10px] font-semibold uppercase tracking-wide text-blue-400">Neu</span>
+                                    </div>
+                                    <select @change="row.new_entity_id = $event.target.value" class="area-select w-full font-mono">
+                                        <option value="" :selected="!row.new_entity_id">— nicht übertragen —</option>
+                                        <template x-for="opt in swapMappingOptions(row)" :key="opt">
+                                            <option :value="opt" :selected="opt === row.new_entity_id" x-text="opt"></option>
+                                        </template>
+                                    </select>
                                 </div>
                             </template>
                         </div>
@@ -2366,7 +2371,7 @@
 
                     <!-- Step 3: Vorschau + Disposition -->
                     <div x-show="swap.step === 3">
-                        <p class="text-sm text-gray-600 mb-3">Das neue Gerät erhält den Namen <strong class="text-gray-900" x-text="swap.job?.target_device_name"></strong>. Folgende Referenzen werden umgebogen:</p>
+                        <p class="text-sm text-gray-600 mb-3">Das neue Gerät erhält den Namen <strong class="text-gray-900" x-text="swap.job?.target_device_name"></strong> und den Bereich des alten Geräts. Einstellungen der Entitäten (Icon, „Anzeigen als", Sichtbarkeit, Aktivierung, Bereich) werden – soweit unterstützt – mit übernommen. Folgende Referenzen werden umgebogen:</p>
                         <div class="rounded-lg border border-gray-200 divide-y divide-gray-100 max-h-48 overflow-y-auto mb-5">
                             <template x-for="p in swapActivePairs()" :key="p.old_entity_id">
                                 <div class="flex items-center gap-2 px-3 py-2 text-xs font-mono">

--- a/tests/test_device_swap.py
+++ b/tests/test_device_swap.py
@@ -1,13 +1,7 @@
 """Tests for the device swap engine: mapping, prefix swap, friendly names, executor flow."""
 
 import device_swap
-from device_swap import (
-    SwapExecutor,
-    SwapJobStore,
-    _common_prefix_tokens,
-    _entity_name,
-    propose_mapping,
-)
+from device_swap import SwapExecutor, SwapJobStore, _common_prefix_tokens, _entity_name, propose_mapping
 
 # --------------------------------------------------------------------------- #
 # Pure helpers: prefix / suffix
@@ -112,12 +106,22 @@ class _DR(_Rec):
     async def rename_device(self, dev, name):
         self.calls.append(("dev", dev, name))
 
+    async def assign_area(self, dev, area_id):
+        self.calls.append(("area", dev, area_id))
+
 
 class _ER(_Rec):
     ws = object()
 
+    def __init__(self):
+        super().__init__()
+        self.updates = []
+
     async def rename_entity(self, old, new, friendly=None):
         self.calls.append((old, new))
+
+    async def update_entity(self, entity_id, **kwargs):
+        self.updates.append((entity_id, kwargs))
 
 
 class _DU(_Rec):
@@ -227,6 +231,88 @@ def test_executor_idempotent_resume(tmp_path):
     ex = SwapExecutor(store, _DR(), _ER(), _DU(), _Bridge(), _RS(), states_by_id={}, timestamp="t2")
     again = asyncio.run(ex.run(out))
     assert again["state"] == device_swap.STATE_COMPLETED
+
+
+# --------------------------------------------------------------------------- #
+# Area assignment + entity settings transfer
+# --------------------------------------------------------------------------- #
+
+
+def test_executor_assigns_old_area_to_new_device(tmp_path):
+    job = _job()
+    job["old_device"]["area_id"] = "bathroom"
+    dr = _DR()
+    store = SwapJobStore(str(tmp_path))
+    ex = SwapExecutor(store, dr, _ER(), _DU(), _Bridge(), _RS(), states_by_id={}, timestamp="t1")
+    import asyncio
+
+    asyncio.run(ex.run(job))
+    assert ("area", "new", "bathroom") in dr.calls
+
+
+def _job_with_settings():
+    job = _job()
+    job["property_pairs"] = {
+        "binary_sensor.kuche_fenster_zustand": "binary_sensor.kuche_fenster_ikea_zustand",
+        "sensor.kuche_fenster_batterie": "sensor.kuche_fenster_ikea_batterie",
+    }
+    job["old_entity_props"] = {
+        "binary_sensor.kuche_fenster_zustand": {
+            "icon": "mdi:window",
+            "area_id": "bathroom",
+            "hidden_by": "user",
+            "disabled_by": None,
+            "entity_category": None,
+            "device_class": "window",
+        },
+        "sensor.kuche_fenster_batterie": {
+            "icon": None,
+            "area_id": None,
+            "hidden_by": None,
+            "disabled_by": "user",
+            "entity_category": "diagnostic",
+            "device_class": None,
+        },
+    }
+    return job
+
+
+def test_executor_transfers_settings_to_final_ids(tmp_path):
+    store = SwapJobStore(str(tmp_path))
+    er = _ER()
+    ex = SwapExecutor(store, _DR(), er, _DU(), _Bridge(), _RS(), states_by_id={}, timestamp="t1")
+    import asyncio
+
+    asyncio.run(ex.run(_job_with_settings()))
+    updates = dict(er.updates)
+
+    # binary_sensor: full copy incl. user-hidden, keyed by the final (suffix) id
+    assert updates["binary_sensor.kuche_fenster_zustand"] == {
+        "area_id": "bathroom",
+        "icon": "mdi:window",
+        "device_class": "window",
+        "hidden_by": "user",
+    }
+    # sensor: area None (use device area), user-disabled + category; no icon/device_class
+    assert updates["sensor.kuche_fenster_batterie"] == {
+        "area_id": None,
+        "entity_category": "diagnostic",
+        "disabled_by": "user",
+    }
+
+
+def test_executor_settings_transfer_idempotent(tmp_path):
+    store = SwapJobStore(str(tmp_path))
+    job = _job_with_settings()
+    ex = SwapExecutor(store, _DR(), _ER(), _DU(), _Bridge(), _RS(), states_by_id={}, timestamp="t1")
+    import asyncio
+
+    out = asyncio.run(ex.run(job))
+    er2 = _ER()
+    ex2 = SwapExecutor(store, _DR(), er2, _DU(), _Bridge(), _RS(), states_by_id={}, timestamp="t2")
+    asyncio.run(ex2.run(out))
+    # already transferred on the first run -> second run does not re-update
+    assert er2.updates == []
 
 
 # --------------------------------------------------------------------------- #

--- a/web_ui.py
+++ b/web_ui.py
@@ -2981,6 +2981,7 @@ def _device_snapshot(restructurer, device_id: str) -> dict:
     return {
         "device_id": device_id,
         "name": d.get("name_by_user") or d.get("name") or "",
+        "area_id": d.get("area_id"),
         "integrations": extract_integrations(d),
         "config_entries": d.get("config_entries", []),
         "identifiers": d.get("identifiers", []),
@@ -2990,6 +2991,30 @@ def _device_snapshot(restructurer, device_id: str) -> dict:
 def _device_entities(restructurer, device_id: str) -> list:
     """Alle Entity-Registry-Einträge eines Geräts."""
     return [e for e in restructurer.entities.values() if e.get("device_id") == device_id]
+
+
+async def _capture_entity_props(entry: dict, entity_registry) -> dict:
+    """Snapshot the user-configurable overrides of a single entity for a swap.
+
+    icon / area_id / hidden_by / disabled_by / entity_category come from the registry
+    list entry; device_class ("display as") is only in the extended entry, so it is
+    fetched via get_entity. Returns a plain dict that is persisted with the swap job.
+    """
+    props = {
+        "icon": entry.get("icon"),
+        "area_id": entry.get("area_id"),
+        "hidden_by": entry.get("hidden_by"),
+        "disabled_by": entry.get("disabled_by"),
+        "entity_category": entry.get("entity_category"),
+        "device_class": None,
+    }
+    try:
+        extended = await entity_registry.get_entity(entry["entity_id"])
+        if extended:
+            props["device_class"] = extended.get("device_class")
+    except Exception as error:  # noqa: BLE001 - a missing device_class must not block the swap
+        logger.warning("Could not read device_class for %s: %s", entry.get("entity_id"), error)
+    return props
 
 
 @app.route("/api/bridge/status", methods=["GET"])
@@ -3096,11 +3121,20 @@ async def _swap_propose_async():
     client = await init_client()
     states = await client.get_states()
     dashboard_refs = set()
+    old_entity_props = {}
     ws = HomeAssistantWebSocket(_ws_url(), os.getenv("HA_TOKEN"))
     await ws.connect()
     try:
         await renamer_state["restructurer"].load_structure(ws)
         dashboard_refs = await LovelaceUpdater(ws).get_referenced_entity_ids()
+        # Snapshot the old entities' settings while nothing has been renamed yet.
+        # Captured here (ws open) so the device_class override, which the registry
+        # list omits, can be fetched via get_entity. Persisted in the job so the
+        # transfer survives crashes/resume regardless of later renames.
+        if old_id in renamer_state["restructurer"].devices:
+            old_entity_registry = EntityRegistry(ws)
+            for entry in _device_entities(renamer_state["restructurer"], old_id):
+                old_entity_props[entry["entity_id"]] = await _capture_entity_props(entry, old_entity_registry)
     finally:
         await ws.disconnect()
 
@@ -3124,6 +3158,11 @@ async def _swap_propose_async():
     proposal["old_total"] = len(old_ents)
     proposal["old_in_use"] = len([e for e in old_ents if e.get("entity_id") in referenced])
 
+    # Vollständiges Pairing (alle Entities, nicht nur in-use) für die Settings-
+    # Übertragung. Die vom Nutzer bestätigten in-use-Paare überschreiben das später.
+    full = propose_mapping(old_ents, new_ents, states_by_id, in_use_ids=None)
+    property_pairs = {p["old_entity_id"]: p["new_entity_id"] for p in full["pairs"]}
+
     old_snap = _device_snapshot(restructurer, old_id)
     new_snap = _device_snapshot(restructurer, new_id)
 
@@ -3141,6 +3180,9 @@ async def _swap_propose_async():
         # ALLE alten Entities (müssen freigemacht werden) und ALLE neuen (werden umbenannt)
         "old_device_entities": sorted(e["entity_id"] for e in old_ents),
         "new_device_entities": sorted(e["entity_id"] for e in new_ents),
+        # Settings-Übertragung alt -> neu (Bereich des Geräts + Entity-Overrides).
+        "property_pairs": property_pairs,
+        "old_entity_props": old_entity_props,
         "proposal": proposal,
         "entity_mapping": [],
         "steps": {},


### PR DESCRIPTION
## What

When replacing a device via the swap wizard, the new device now inherits the old device's settings, so the result matches the original as closely as Home Assistant allows.

### Settings carried over
- **Device area** — the new device is assigned the old device's area. Entities that inherit their area from the device follow automatically.
- **Per-entity user overrides** copied onto the matching new entities (only where HA supports it):
  - `icon`
  - `device_class` ("display as")
  - `entity_category`
  - entity **area override** (`None` = "use device area", which now points at the inherited device area)
  - user-set **hidden**/**disabled** flags

Only user-level state is replicated; integration-forced values are left untouched.

### How it works
- Old entity settings are snapshotted at **propose** time and persisted with the job. This includes the `device_class` override, which `config/entity_registry/list` omits, so it is fetched via `config/entity_registry/get`.
- A new idempotent **`TRANSFERRING_SETTINGS`** step (after entity rename) applies them — crash-safe and resumable like the rest of the swap.
- Pairing uses the full auto-mapping; the user's confirmed in-use mapping takes precedence.
- `EntityRegistry.update_entity` was extended to send `icon` / `area_id` / `hidden_by` / `entity_category` / `device_class` (sentinel-based so an explicit `None` is distinguishable from "leave untouched").

### Mapping UI (step 2)
Reworked so long entity IDs are readable: old and new entity are shown as two **equally-wide, full-width fields** with matching padding — long IDs wrap instead of truncating and the columns line up. `device_class` shown as a badge.

## Tests
- New tests: device area assignment, settings transfer to final IDs, transfer idempotency on resume.
- Full suite green (74 passed), Black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)