### PR TITLE
feat: use slugify for full non-ASCII entity name normalization

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -80,7 +80,7 @@ echo "Source: ${DEPLOY_REF:-working tree}"
 echo ""
 
 # Check SSH connection
-echo -e "[1/4] Testing SSH connection..."
+echo -e "[1/5] Testing SSH connection..."
 if ! ssh -q -p "$SSH_PORT" "$SSH_USER@$HA_HOST" "exit" 2>/dev/null; then
     echo -e "${RED}ERROR: Cannot connect to $HA_HOST${NC}"
     exit 1
@@ -88,7 +88,7 @@ fi
 echo -e "${GREEN}SSH OK${NC}"
 
 # Check container is running
-echo -e "[2/4] Checking container..."
+echo -e "[2/5] Checking container..."
 if ! ssh -p "$SSH_PORT" "$SSH_USER@$HA_HOST" "docker ps -q -f name=$CONTAINER" | grep -q .; then
     echo -e "${RED}ERROR: Container $CONTAINER is not running${NC}"
     exit 1
@@ -96,7 +96,7 @@ fi
 echo -e "${GREEN}Container running${NC}"
 
 # Deploy files
-echo -e "[3/4] Deploying files to container..."
+echo -e "[3/5] Deploying files to container..."
 ( cd "$SOURCE_DIR" && tar czf - \
     --exclude='__pycache__' \
     --exclude='*.pyc' \
@@ -116,13 +116,28 @@ echo -e "[3/4] Deploying files to container..."
     --exclude='.ruff.toml' \
     --exclude='.env' \
     --exclude='.env.example' \
-    *.py templates/ static/ translations/ 2>/dev/null ) | \
+    *.py requirements.txt templates/ static/ translations/ 2>/dev/null ) | \
     ssh -p "$SSH_PORT" "$SSH_USER@$HA_HOST" "docker exec -i $CONTAINER tar xzf - -C $APP_PATH"
 
 echo -e "${GREEN}Files deployed${NC}"
 
+# Ensure Python dependencies are present in the container.
+# deploy.sh is a volatile, test-only deploy into the running container's
+# writable layer (gone on a Supervisor recreate). The base image only has the
+# deps from the last add-on build, so a freshly added requirement (e.g. a new
+# pip package in requirements.txt) would be missing and the app would crash on
+# import. Installing here makes the deployed code actually runnable for testing;
+# the durable install still comes from an add-on rebuild off main.
+echo -e "[4/5] Ensuring dependencies (pip install -r requirements.txt)..."
+if ! ssh -p "$SSH_PORT" "$SSH_USER@$HA_HOST" \
+    "docker exec $CONTAINER pip install --root-user-action=ignore -r $APP_PATH/requirements.txt"; then
+    echo -e "${RED}ERROR: dependency installation failed -- aborting before restart${NC}"
+    exit 1
+fi
+echo -e "${GREEN}Dependencies ready${NC}"
+
 # Restart container
-echo -e "[4/4] Restarting container..."
+echo -e "[5/5] Restarting container..."
 ssh -p "$SSH_PORT" "$SSH_USER@$HA_HOST" "docker restart $CONTAINER"
 
 echo ""

--- a/entity_restructurer.py
+++ b/entity_restructurer.py
@@ -16,6 +16,7 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from ha_client import HomeAssistantClient
+from hierarchy_manager import normalize_name
 from naming_overrides import NamingOverrides
 
 # Import new modules - optional for backward compatibility
@@ -112,33 +113,12 @@ class EntityRestructurer:
         }
 
     def normalize_name(self, name: str) -> str:
-        """Normalize names for entity IDs (HA standard)"""
-        if not name:
-            return ""
+        """Normalize names for entity IDs (HA standard).
 
-        # Replace umlauts according to HA standard
-        replacements = {
-            "ä": "a",
-            "ö": "o",
-            "ü": "u",
-            "ß": "ss",
-            "Ä": "a",
-            "Ö": "o",
-            "Ü": "u",
-        }
-
-        normalized = name.lower()
-        for old, new in replacements.items():
-            normalized = normalized.replace(old, new)
-
-        # Only alphanumeric and underscores
-        import re
-
-        normalized = re.sub(r"[^a-z0-9]+", "_", normalized)
-        normalized = re.sub(r"_+", "_", normalized)
-        normalized = normalized.strip("_")
-
-        return normalized
+        Delegates to :func:`hierarchy_manager.normalize_name` so the whole
+        code base shares a single normalization implementation.
+        """
+        return normalize_name(name)
 
     async def load_structure(self, ws_client=None):
         """

--- a/hierarchy_manager.py
+++ b/hierarchy_manager.py
@@ -13,8 +13,9 @@ Changes at higher levels automatically cascade to all descendants.
 from dataclasses import dataclass, field
 from datetime import datetime
 import logging
-import re
 from typing import Any, Dict, List, Optional, Set, Tuple
+
+from slugify import slugify
 
 logger = logging.getLogger(__name__)
 
@@ -23,40 +24,30 @@ def normalize_name(name: str) -> str:
     """
     Normalize names for entity IDs (Home Assistant standard).
 
-    Converts to lowercase, replaces umlauts, removes special characters.
+    Transliterates non-ASCII characters (diacritics, umlauts, etc.) to their
+    closest ASCII equivalents, lowercases the result and joins tokens with
+    underscores. This mirrors how Home Assistant itself derives entity IDs,
+    which relies on ``python-slugify`` (see ``homeassistant.util.slugify``),
+    so accented characters like ``á``, ``é`` or ``ł`` are transliterated
+    instead of being stripped.
+
+    Examples:
+        normalize_name("Zażółć gęślą jaźń") -> "zazolc_gesla_jazn"
+        normalize_name("Wohnzimmer Büro") -> "wohnzimmer_buro"
 
     Args:
         name: The name to normalize
 
     Returns:
-        Normalized string suitable for entity IDs
+        Normalized string suitable for entity IDs. Returns an empty string if
+        the input is empty or contains no usable characters.
     """
     if not name:
         return ""
 
-    # Replace German umlauts according to HA standard
-    replacements = {
-        "ä": "a",
-        "ö": "o",
-        "ü": "u",
-        "ß": "ss",
-        "Ä": "a",
-        "Ö": "o",
-        "Ü": "u",
-    }
-
-    normalized = name.lower()
-    for old, new in replacements.items():
-        normalized = normalized.replace(old, new)
-
-    # Replace special characters with underscores
-    normalized = re.sub(r"[^a-z0-9]+", "_", normalized)
-    # Remove duplicate underscores
-    normalized = re.sub(r"_+", "_", normalized)
-    # Remove leading/trailing underscores
-    normalized = normalized.strip("_")
-
-    return normalized
+    # ``slugify`` lowercases, transliterates via unidecode, replaces every run
+    # of unsupported characters with the separator and trims/collapses them.
+    return slugify(name, separator="_")
 
 
 def strip_prefix(full_name: str, prefix: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ flask[async]>=2.3.0
 flask-cors>=4.0.0
 nest_asyncio>=1.5.0
 paho-mqtt>=2.0.0
+python-slugify>=8.0.4

--- a/templates/index.html
+++ b/templates/index.html
@@ -3716,10 +3716,8 @@
 
                 // Get new entity ID
                 getNewEntityId(entity) {
-                    const domain = entity.id.split('.')[0];
-                    const friendlyName = this.getEntityFriendlyName(entity);
-                    const normalized = this.normalizeName(friendlyName);
-                    return `${domain}.${normalized}`;
+                    // Backend-computed slug is the single source of truth (see fetchNormalized).
+                    return entity._previewId || entity.id;
                 },
 
                 // Live preview versions - use _editValue for real-time updates
@@ -3747,22 +3745,35 @@
                 },
 
                 getNewEntityIdLive(entity) {
-                    const domain = entity.id.split('.')[0];
-                    const friendlyName = this.getEntityFriendlyNameLive(entity);
-                    const normalized = this.normalizeName(friendlyName);
-                    return `${domain}.${normalized}`;
+                    // Backend-computed slug is the single source of truth (see fetchNormalized).
+                    return entity._previewId || entity.id;
                 },
 
-                // Normalize name for entity ID
-                normalizeName(name) {
-                    if (!name) return '';
-                    const replacements = {'ä': 'a', 'ö': 'o', 'ü': 'u', 'ß': 'ss', 'Ä': 'a', 'Ö': 'o', 'Ü': 'u'};
-                    let normalized = name.toLowerCase();
-                    for (const [from, to] of Object.entries(replacements)) {
-                        normalized = normalized.split(from).join(to);
+                // Normalize display names to entity-ID slugs via the backend.
+                // The backend (normalize_name / slugify) is the single source of truth for
+                // the naming convention -- the frontend must NOT reimplement the slug rules,
+                // otherwise the two drift apart (e.g. accented characters get stripped here).
+                async fetchNormalized(names) {
+                    if (!names.length) return [];
+                    try {
+                        const resp = await fetch('api/normalize', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ names })
+                        });
+                        if (!resp.ok) throw new Error('normalize HTTP ' + resp.status);
+                        const data = await resp.json();
+                        return Array.isArray(data.normalized) ? data.normalized : names.map(() => '');
+                    } catch (e) {
+                        console.error('normalize failed', e);
+                        return names.map(() => '');
                     }
-                    normalized = normalized.replace(/[^a-z0-9]+/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '');
-                    return normalized;
+                },
+
+                // Build the entity ID from a domain and a backend-provided slug.
+                composeEntityId(entity, slug) {
+                    const domain = entity.id.split('.')[0];
+                    return slug ? `${domain}.${slug}` : entity.id;
                 },
 
                 // Check if entity needs rename (uses entity's own device/area context)
@@ -3815,24 +3826,33 @@
 
                 // Get new entity ID using entity's own context
                 getNewEntityIdForEntity(entity) {
-                    const domain = entity.id.split('.')[0];
-                    const friendlyName = entity._previewName || this.getEntityFriendlyNameForEntity(entity);
-                    const normalized = this.normalizeName(friendlyName);
-                    return `${domain}.${normalized}`;
+                    // Backend-computed slug is the single source of truth (see fetchNormalized).
+                    return entity._previewId || entity.id;
                 },
 
                 // Precompute preview values for all entities (called once after loading)
                 precomputeEntityPreviews() {
                     if (!this.hierarchy?.entities) return;
 
+                    const pending = [];
                     for (const entity of this.hierarchy.entities) {
                         // Skip if already computed (e.g. from user edit) or just renamed
                         if (entity._previewName || entity._justRenamed) continue;
 
-                        // Compute and cache preview values
+                        // Friendly-name composition stays client-side; only the slug comes
+                        // from the backend (source of truth).
                         entity._previewName = this.getEntityFriendlyNameForEntity(entity);
-                        entity._previewId = this.getNewEntityIdForEntity(entity);
+                        pending.push(entity);
                     }
+                    if (!pending.length) return;
+
+                    this.fetchNormalized(pending.map(e => e._previewName)).then(slugs => {
+                        pending.forEach((entity, i) => {
+                            entity._previewId = this.composeEntityId(entity, slugs[i]);
+                        });
+                        // Force Alpine to re-evaluate dependent expressions
+                        this.previewVersion++;
+                    });
                 },
 
                 // Invalidate cached previews (call after rename to refresh conflict detection)
@@ -4183,10 +4203,20 @@
                     }
 
                     const friendlyName = parts.filter(p => p).join(' ');
-                    const entityId = entity.id.split('.')[0] + '.' + this.normalizeName(friendlyName);
-
                     entity._previewName = friendlyName;
-                    entity._previewId = entityId;
+
+                    // Slug comes from the backend (source of truth), debounced so we don't
+                    // fire a request on every keystroke. The friendly-name preview updates
+                    // instantly; the ID follows a moment later.
+                    if (!this._normTimers) this._normTimers = {};
+                    const key = entity.registry_id || entity.id;
+                    clearTimeout(this._normTimers[key]);
+                    this._normTimers[key] = setTimeout(() => {
+                        this.fetchNormalized([friendlyName]).then(slugs => {
+                            entity._previewId = this.composeEntityId(entity, slugs[0]);
+                            this.previewVersion++;
+                        });
+                    }, 200);
 
                     // Force Alpine to re-evaluate dependent expressions
                     this.previewVersion++;
@@ -4461,9 +4491,12 @@
                     if (!entity) return;
 
                     try {
-                        // Calculate new names using base_name and type mappings
-                        const newId = this.getNewEntityId(entity);
-                        const newName = this.getEntityFriendlyName(entity);
+                        // Friendly name reflects the (possibly just-typed) suffix preview;
+                        // the slug comes fresh from the backend (source of truth) to avoid a
+                        // debounce race with the live preview.
+                        const newName = entity._previewName || this.getEntityFriendlyName(entity);
+                        const [slug] = await this.fetchNormalized([newName]);
+                        const newId = this.composeEntityId(entity, slug);
 
                         // Prevent renaming to an entity ID that another entity already uses
                         if (newId !== entity.id &&

--- a/tests/test_normalize_name.py
+++ b/tests/test_normalize_name.py
@@ -1,0 +1,65 @@
+"""Tests for entity-ID name normalization.
+
+Home Assistant derives entity IDs via ``python-slugify`` (see
+``homeassistant.util.slugify``), which transliterates non-ASCII characters to
+their closest ASCII equivalents instead of stripping them. ``normalize_name``
+must produce the same slugs so renamed entities match what HA would generate.
+
+The expected values below were provided in issue #58 by reproducing HA's
+"Recreate entity IDs" for several languages.
+"""
+
+import pytest
+
+from hierarchy_manager import normalize_name
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # Czech
+        (
+            "Příliš žluťoučký kůň úpěl ďábelské ódy",
+            "prilis_zlutoucky_kun_upel_dabelske_ody",
+        ),
+        # Polish
+        ("Zażółć gęślą jaźń", "zazolc_gesla_jazn"),
+        # Hungarian
+        ("Árvíztűrő tükörfúrógép", "arvizturo_tukorfurogep"),
+        # German (umlauts + ß)
+        (
+            "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg.",
+            "falsches_uben_von_xylophonmusik_qualt_jeden_grosseren_zwerg",
+        ),
+        # French (accents + apostrophe)
+        (
+            "L'épagneul français a hâte de manger son gâteau sur le canapé déjà usé.",
+            "l_epagneul_francais_a_hate_de_manger_son_gateau_sur_le_canape_deja_use",
+        ),
+    ],
+)
+def test_transliterates_non_ascii(text: str, expected: str) -> None:
+    """Accented characters are transliterated, matching HA's entity IDs."""
+    assert normalize_name(text) == expected
+
+
+def test_german_umlauts() -> None:
+    """The original German-only behaviour is preserved (ä/ö/ü/ß)."""
+    assert normalize_name("Wohnzimmer Büro") == "wohnzimmer_buro"
+    assert normalize_name("Straße") == "strasse"
+
+
+def test_collapses_and_trims_separators() -> None:
+    """Runs of unsupported characters collapse to a single underscore."""
+    assert normalize_name("  Hello --- World!!  ") == "hello_world"
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_empty_input_returns_empty_string(value) -> None:
+    """Empty/None input yields an empty string (not HA's ``unknown``)."""
+    assert normalize_name(value) == ""
+
+
+def test_input_without_usable_characters_returns_empty_string() -> None:
+    """Input that slugifies to nothing yields an empty string."""
+    assert normalize_name("---") == ""

--- a/web_ui.py
+++ b/web_ui.py
@@ -760,6 +760,28 @@ async def _get_areas_async():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/api/normalize", methods=["POST"])
+def normalize_names():
+    """Normalize display names to entity-ID slugs.
+
+    The backend is the single source of truth for the naming convention, so the
+    frontend must call this instead of reimplementing the slug rules (otherwise
+    the two drift apart -- e.g. accented characters get stripped client-side).
+
+    Body: ``{"names": ["Foo Bar", ...]}`` -> ``{"normalized": ["foo_bar", ...]}``
+    """
+    data = request.json
+    if not isinstance(data, dict) or not isinstance(data.get("names"), list):
+        return jsonify({"error": "'names' must be a list"}), 400
+
+    names = data["names"]
+    if len(names) > 5000:
+        return jsonify({"error": "Too many names"}), 400
+
+    normalized = [normalize_name(n) if isinstance(n, str) else "" for n in names]
+    return jsonify({"normalized": normalized})
+
+
 @app.route("/api/preview", methods=["POST"])
 def preview_changes():
     """Zeige Vorschau der Änderungen für ausgewählte Area/Domain"""


### PR DESCRIPTION
## Summary

Entity ID normalization only handled German umlauts (`ä/ö/ü/ß`) and stripped every other diacritic, so accented names were mangled and never matched the IDs Home Assistant itself generates:

- `Zażółć` → `za_o_c`, `café` → `caf`, `Příliš` → `p_ili`

This replaces the hand-rolled logic with [`python-slugify`](https://pypi.org/project/python-slugify/) — the same library `homeassistant.util.slugify` relies on — which transliterates non-ASCII characters to their closest ASCII equivalents. German output is **byte-identical** to before (`ä→a`, `ö→o`, `ü→u`, `ß→ss`); Czech/Polish/Hungarian/French and others now transliterate correctly.

## Changes

- **`hierarchy_manager.normalize_name`**: slugify-based, single source of truth.
- **`entity_restructurer.normalize_name`**: delegates to it (DRY — drops the duplicated umlaut table).
- **`web_ui`**: new `POST /api/normalize` endpoint so the frontend stops reimplementing the slug rules and uses the backend as the source of truth.
- **`templates/index.html`**: removed the client-side `normalizeName`; entity-ID previews and rename targets now come from `/api/normalize` (batched for the list, debounced for live suffix edits, fetched fresh on save — this was the reason accented suffixes still showed mangled IDs like `k_pe_a_svetlo` in the UI even with the backend fixed).
- **`deploy.sh`**: installs `requirements.txt` into the container and ships it, so newly added deps (like `python-slugify`) are present when testing a build.
- **tests**: regression cases for every language reported in the issue.

## Verification

Reproduced the reporter's expected outputs exactly (Czech/Polish/Hungarian/German/French), confirmed German results are unchanged, and verified live in the running add-on that suffix input `Kúpeľňa svetlo` now yields `…_kupelna_svetlo`.

Closes #58