### PR TITLE
feat: track long-running operations as async background jobs

### DIFF
--- a/device_swap.py
+++ b/device_swap.py
@@ -16,11 +16,10 @@ Dieses Modul enthält die Persistenz (SwapJobStore), den Mapping-Vorschlag
 injiziert; dieses Modul kennt keine Flask-/Request-Details.
 """
 
-import json
 import logging
-import os
-from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from jobs import JobStore
 
 logger = logging.getLogger(__name__)
 
@@ -60,61 +59,21 @@ DISPOSITION_DELETE = "delete"
 # --------------------------------------------------------------------------- #
 
 
-class SwapJobStore:
-    """Persistiert Swap-Jobs als einzelne JSON-Dateien unter /data/device_swaps."""
+class SwapJobStore(JobStore):
+    """Persists swap jobs as JSON files under /data/device_swaps.
 
-    def __init__(self, storage_dir: str = "/data/device_swaps"):
-        self.storage_dir = Path(storage_dir)
-        self.storage_dir.mkdir(parents=True, exist_ok=True)
+    Reuses the generic :class:`jobs.JobStore` (atomic writes, save/load/list)
+    and only pins the swap-specific terminal states and schema version, so the
+    swap schema, executor and resume flow stay unchanged.
+    """
 
-    def _path(self, job_id: str) -> Path:
-        # job_id ist ein uuid4-hex; defensiv nur den Basename verwenden.
-        safe = os.path.basename(job_id)
-        return self.storage_dir / f"{safe}.json"
-
-    def save(self, job: Dict[str, Any]) -> None:
-        """Schreibt einen Job atomar (temp-Datei + os.replace)."""
-        job["version"] = SCHEMA_VERSION
-        path = self._path(job["job_id"])
-        tmp = path.with_suffix(".json.tmp")
-        try:
-            with open(tmp, "w", encoding="utf-8") as f:
-                json.dump(job, f, indent=2, ensure_ascii=False)
-            os.replace(tmp, path)
-        except Exception as e:
-            logger.error(f"Failed to save swap job {job.get('job_id')}: {e}")
-            raise
-
-    def load(self, job_id: str) -> Optional[Dict[str, Any]]:
-        path = self._path(job_id)
-        if not path.exists():
-            return None
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
-            logger.error(f"Failed to load swap job {job_id}: {e}")
-            return None
-
-    def list_jobs(self) -> List[Dict[str, Any]]:
-        jobs = []
-        for path in sorted(self.storage_dir.glob("*.json")):
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    jobs.append(json.load(f))
-            except (json.JSONDecodeError, IOError) as e:
-                logger.warning(f"Skipping unreadable swap job {path.name}: {e}")
-        return jobs
-
-    def list_unfinished(self) -> List[Dict[str, Any]]:
-        """Alle Jobs, die noch fortgesetzt werden können (für Resume-UI)."""
-        terminal = {STATE_COMPLETED, STATE_ABORTED}
-        return [j for j in self.list_jobs() if j.get("state") not in terminal]
-
-    def delete(self, job_id: str) -> None:
-        path = self._path(job_id)
-        if path.exists():
-            path.unlink()
+    def __init__(self, storage_dir: str = "/data/device_swaps") -> None:
+        """Create the swap store with swap terminal states and schema version."""
+        super().__init__(
+            storage_dir,
+            terminal_states={STATE_COMPLETED, STATE_ABORTED},
+            schema_version=SCHEMA_VERSION,
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -387,7 +346,12 @@ class SwapExecutor:
         # Entity-Bezeichnung (Suffix des Friendly-Namens) bleibt erhalten.
         old_dev_name = (job.get("new_device") or {}).get("name", "")
         target_name = job.get("target_device_name", "")
-        for current in job.get("new_device_entities", []):
+        new_entities = job.get("new_device_entities", [])
+        total = len(new_entities)
+        # Surface entity-rename progress on the job so the UI can show a bar while
+        # polling; this is the long phase of the swap.
+        job["progress"] = {"done": len(renamed), "total": total, "current": ""}
+        for current in new_entities:
             if current in renamed:
                 continue  # idempotent (Resume)
             suffix = _entity_name(current, new_prefix)  # object_id ohne neuen Device-Präfix
@@ -403,6 +367,7 @@ class SwapExecutor:
                     msg += f" ('{new_friendly}')"
                 self._log(job, STATE_RENAMING_ENTITIES, msg)
             renamed[current] = target
+            job["progress"] = {"done": len(renamed), "total": total, "current": current}
             self._persist(job)
 
     def _swap_friendly(self, entity_id: str, old_dev_name: str, target_name: str) -> Optional[str]:

--- a/jobs.py
+++ b/jobs.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Generic background-job infrastructure for long-running operations.
+
+Long-running registry operations (renaming a device with many entities, batch
+restructuring, device swaps) used to run synchronously inside the Flask request.
+For large devices that exceeds the Ingress/proxy timeout: the client sees an
+error toast while the work silently keeps running to completion with no visible
+progress.
+
+This module provides a small, Flask-agnostic building block to run such work as
+a tracked background job instead:
+
+* :class:`JobStore` persists jobs as atomic JSON files (like ``SwapJobStore``).
+* :func:`new_job` creates the canonical job dict.
+* :class:`JobContext` is handed to a job handler so it can report progress and
+  log lines that get persisted (throttled) as the job runs.
+* :class:`JobWorker` is a single, long-lived worker thread that runs queued jobs
+  serially on one asyncio loop, guarded by a shared registry lock so registry
+  mutations never overlap with concurrent request handlers.
+
+The module knows nothing about Flask, Home Assistant or the concrete handlers;
+those are injected. ``device_swap.SwapJobStore`` is a thin subclass of
+:class:`JobStore`.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+import queue
+import threading
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# Generic job states. Swap jobs keep their own richer state machine and are only
+# wrapped by a generic job whose state we do not surface to the swap UI.
+STATE_QUEUED = "queued"
+STATE_RUNNING = "running"
+STATE_COMPLETED = "completed"
+STATE_FAILED = "failed"
+
+# States a generic job can no longer progress from (used for reconnect filtering).
+TERMINAL_STATES: Set[str] = {STATE_COMPLETED, STATE_FAILED}
+
+# Type of a job handler coroutine: ``async def handler(job, ctx) -> result``.
+JobHandler = Callable[[Dict[str, Any], "JobContext"], Awaitable[Any]]
+
+
+def iso_now() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Persistence
+# --------------------------------------------------------------------------- #
+
+
+class JobStore:
+    """Persists jobs as individual JSON files in ``storage_dir``.
+
+    Writes are atomic (temp file + ``os.replace``) so a crash mid-write never
+    corrupts a job and concurrent readers always see a complete old-or-new file.
+    ``terminal_states`` is injected so different job families (generic vs. swap)
+    can define which states count as finished.
+    """
+
+    def __init__(
+        self,
+        storage_dir: str,
+        *,
+        terminal_states: Set[str],
+        schema_version: int = 1,
+    ) -> None:
+        """Create the store, ensuring ``storage_dir`` exists."""
+        self.storage_dir = Path(storage_dir)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.terminal_states = set(terminal_states)
+        self.schema_version = schema_version
+
+    def _path(self, job_id: str) -> Path:
+        """Return the on-disk path for ``job_id`` (basename only, defensively)."""
+        safe = os.path.basename(job_id)
+        return self.storage_dir / f"{safe}.json"
+
+    def save(self, job: Dict[str, Any]) -> None:
+        """Write a job atomically (temp file + ``os.replace``)."""
+        job["version"] = self.schema_version
+        path = self._path(job["job_id"])
+        tmp = path.with_suffix(".json.tmp")
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(job, f, indent=2, ensure_ascii=False)
+            os.replace(tmp, path)
+        except Exception as e:
+            logger.error(f"Failed to save job {job.get('job_id')}: {e}")
+            raise
+
+    def load(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Load a job by id, or return ``None`` if missing/unreadable."""
+        path = self._path(job_id)
+        if not path.exists():
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError) as e:
+            logger.error(f"Failed to load job {job_id}: {e}")
+            return None
+
+    def list_jobs(self) -> List[Dict[str, Any]]:
+        """Return all readable jobs, skipping unreadable files."""
+        jobs = []
+        for path in sorted(self.storage_dir.glob("*.json")):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    jobs.append(json.load(f))
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(f"Skipping unreadable job {path.name}: {e}")
+        return jobs
+
+    def list_unfinished(self) -> List[Dict[str, Any]]:
+        """Return all jobs that are not in a terminal state (for reconnect UI)."""
+        return [j for j in self.list_jobs() if j.get("state") not in self.terminal_states]
+
+    def delete(self, job_id: str) -> None:
+        """Remove a job file if it exists."""
+        path = self._path(job_id)
+        if path.exists():
+            path.unlink()
+
+
+# --------------------------------------------------------------------------- #
+# Job schema + per-run context
+# --------------------------------------------------------------------------- #
+
+
+def new_job(job_type: str, payload: Dict[str, Any], *, job_id: str) -> Dict[str, Any]:
+    """Build a fresh generic job dict in the ``queued`` state.
+
+    ``payload`` carries everything the handler needs (already read from the Flask
+    request in the request thread, since the worker thread has no request
+    context). ``job_id`` is supplied by the caller (a uuid4 hex) so the caller
+    can persist and enqueue it without a second lookup.
+    """
+    now = iso_now()
+    return {
+        "job_id": job_id,
+        "type": job_type,
+        "state": STATE_QUEUED,
+        "progress": {"done": 0, "total": 0, "current": ""},
+        "log": [],
+        "payload": payload,
+        "result": None,
+        "error": None,
+        "created": now,
+        "updated": now,
+    }
+
+
+class JobContext:
+    """Handed to a job handler to report progress and log lines.
+
+    Progress updates are throttled: persisting on every entity of a large device
+    would fsync dozens of times. We only write to disk when at least
+    ``throttle_seconds`` passed since the last save, or when the job finished
+    (``done >= total``), so the final state is always flushed. Log lines are
+    always persisted (they are comparatively rare and carry the audit trail).
+    """
+
+    def __init__(
+        self,
+        job: Dict[str, Any],
+        store: JobStore,
+        *,
+        throttle_seconds: float = 0.5,
+    ) -> None:
+        """Bind the context to a job and its store."""
+        self.job = job
+        self.store = store
+        self._throttle = throttle_seconds
+        self._last_save = 0.0
+
+    def progress(self, done: int, total: int, current: str = "") -> None:
+        """Update progress and persist it, throttled to avoid excessive writes."""
+        self.job["progress"] = {"done": done, "total": total, "current": current}
+        self.job["updated"] = iso_now()
+        now = time.monotonic()
+        if total <= 0 or done >= total or (now - self._last_save) >= self._throttle:
+            self._last_save = now
+            self.store.save(self.job)
+
+    def log(self, step: str, message: str) -> None:
+        """Append a ``{ts, step, message}`` log line and persist the job."""
+        self.job.setdefault("log", []).append({"ts": iso_now(), "step": step, "message": message})
+        self.job["updated"] = iso_now()
+        self.store.save(self.job)
+
+
+# --------------------------------------------------------------------------- #
+# Worker
+# --------------------------------------------------------------------------- #
+
+
+class JobWorker:
+    """Single background thread that runs queued jobs serially.
+
+    A ``queue.Queue`` of job ids feeds one daemon thread which owns a single,
+    long-lived asyncio loop. Serial execution is intentional: the jobs share
+    ``restructurer`` state and mutate the same Home Assistant registry, so only
+    one runs at a time. Requests keep serving concurrently (the dev server is
+    threaded); ``load_structure`` rebuilds the restructurer by reassignment and
+    handlers iterate over snapshots, so a concurrent read does not need a lock.
+
+    Handlers are registered per job ``type`` and are plain coroutines
+    ``async def handler(job, ctx) -> result``. Their return value becomes
+    ``job["result"]``; a raised exception marks the job ``failed``.
+    """
+
+    def __init__(self, store: JobStore) -> None:
+        """Create the worker bound to a store."""
+        self.store = store
+        self.handlers: Dict[str, JobHandler] = {}
+        self.queue: "queue.Queue[str]" = queue.Queue()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def register(self, job_type: str, handler: JobHandler) -> None:
+        """Register the coroutine handler for a job ``type``."""
+        self.handlers[job_type] = handler
+
+    def start(self) -> None:
+        """Start the worker thread (idempotent)."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, name="job-worker", daemon=True)
+        self._thread.start()
+
+    def enqueue(self, job: Dict[str, Any]) -> None:
+        """Queue an already-persisted job for execution."""
+        self.queue.put(job["job_id"])
+
+    def reconcile_on_start(self) -> None:
+        """Fail jobs left ``queued``/``running`` by a previous process.
+
+        Generic jobs (device rename, batch execute, enable-all) are not safely
+        resumable mid-flight, so an interrupted one is marked ``failed`` with a
+        clear reason instead of showing an eternal spinner after a restart. Swap
+        jobs live in their own store and stay resumable; this only touches this
+        worker's store.
+        """
+        for job in self.store.list_jobs():
+            if job.get("state") in (STATE_QUEUED, STATE_RUNNING):
+                job["state"] = STATE_FAILED
+                job["error"] = "Interrupted by restart"
+                job["updated"] = iso_now()
+                self.store.save(job)
+                logger.info("Reconciled interrupted job %s -> failed", job.get("job_id"))
+
+    def _run(self) -> None:
+        """Worker thread main loop: own an asyncio loop and drain the queue."""
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        while True:
+            job_id = self.queue.get()
+            try:
+                self._process(job_id)
+            except Exception:  # noqa: BLE001 - the worker thread must never die
+                logger.exception("Unexpected error processing job %s", job_id)
+            finally:
+                self.queue.task_done()
+
+    def _process(self, job_id: str) -> None:
+        """Load a queued job and dispatch its handler on the worker loop."""
+        job = self.store.load(job_id)
+        if job is None:
+            logger.warning("Queued job %s vanished before execution", job_id)
+            return
+        handler = self.handlers.get(job.get("type"))
+        if handler is None:
+            job["state"] = STATE_FAILED
+            job["error"] = f"No handler registered for job type '{job.get('type')}'"
+            job["updated"] = iso_now()
+            self.store.save(job)
+            return
+        self._loop.run_until_complete(self._dispatch(job, handler))
+
+    async def _dispatch(self, job: Dict[str, Any], handler: JobHandler) -> None:
+        """Run a handler, tracking ``running``/``completed``/``failed`` state."""
+        job["state"] = STATE_RUNNING
+        job["updated"] = iso_now()
+        self.store.save(job)
+        ctx = JobContext(job, self.store)
+        try:
+            job["result"] = await handler(job, ctx)
+            job["state"] = STATE_COMPLETED
+        except Exception as e:  # noqa: BLE001 - surface any handler failure as job state
+            job["state"] = STATE_FAILED
+            job["error"] = str(e)
+            ctx.log("ERROR", str(e))
+            logger.exception("Job %s (%s) failed", job.get("job_id"), job.get("type"))
+        job["updated"] = iso_now()
+        self.store.save(job)

--- a/jobs.py
+++ b/jobs.py
@@ -15,8 +15,8 @@ a tracked background job instead:
 * :class:`JobContext` is handed to a job handler so it can report progress and
   log lines that get persisted (throttled) as the job runs.
 * :class:`JobWorker` is a single, long-lived worker thread that runs queued jobs
-  serially on one asyncio loop, guarded by a shared registry lock so registry
-  mutations never overlap with concurrent request handlers.
+  serially on one asyncio loop, off the request path, so registry-mutating work
+  never overlaps and enqueue/poll requests stay fast.
 
 The module knows nothing about Flask, Home Assistant or the concrete handlers;
 those are injected. ``device_swap.SwapJobStore`` is a thin subclass of
@@ -212,8 +212,8 @@ class JobWorker:
     A ``queue.Queue`` of job ids feeds one daemon thread which owns a single,
     long-lived asyncio loop. Serial execution is intentional: the jobs share
     ``restructurer`` state and mutate the same Home Assistant registry, so only
-    one runs at a time. Requests keep serving concurrently (the dev server is
-    threaded); ``load_structure`` rebuilds the restructurer by reassignment and
+    one runs at a time. The work runs on this dedicated thread, off the request
+    path; ``load_structure`` rebuilds the restructurer by reassignment and
     handlers iterate over snapshots, so a concurrent read does not need a lock.
 
     Handlers are registered per job ``type`` and are plain coroutines

--- a/templates/index.html
+++ b/templates/index.html
@@ -4760,6 +4760,23 @@
                         const data = await fetch('api/jobs').then(r => r.json()).catch(() => ({ jobs: [] }));
                         const running = (data.jobs || []).find(j => !this.isJobTerminal(j));
                         if (!running) return;
+                        // A device swap runs via a generic wrapper job, but its progress
+                        // and modal live in swap_store (api/swap/<id>). Re-attach to the
+                        // real swap modal and poll it, instead of the empty generic panel.
+                        // Do NOT call swapResume(): the swap is already executing, so we
+                        // only watch it (re-triggering execute would enqueue a duplicate).
+                        if (running.type === 'swap') {
+                            const swapId = running.payload && running.payload.swap_job_id;
+                            if (!swapId) return;
+                            const j = await fetch('api/swap/' + swapId).then(r => r.json()).catch(() => null);
+                            if (j && !j.error) {
+                                this.swap.job = j;
+                                this.swap.show = true;
+                                this.swap.step = 4;
+                                this.startSwapPolling();
+                            }
+                            return;
+                        }
                         const meta = this.jobKindMeta(running.type);
                         this.startJob('api/jobs/' + running.job_id, running, {
                             kind: running.type, titleKey: meta.titleKey, onDone: meta.onDone

--- a/templates/index.html
+++ b/templates/index.html
@@ -2127,13 +2127,11 @@
                     </button>
                     <button @click="executeAllChanges()"
                             x-show="pendingChangesCount > 0"
-                            :disabled="executing || applyingEntityId || renamingDevice"
+                            :disabled="applyingEntityId || renamingDevice"
                             class="btn btn-success"
-                            :class="{'opacity-50 cursor-not-allowed': executing || applyingEntityId || renamingDevice}">
-                        <i class="ri-check-double-line mr-2" x-show="!executing"></i>
-                        <i class="ri-loader-4-line animate-spin mr-2" x-show="executing"></i>
-                        <span x-show="!executing" x-text="t('action_bar.apply_all')">Apply All Changes</span>
-                        <span x-show="executing" x-text="executingTotal > 0 ? `${executingProgress}/${executingTotal}` : t('action_bar.applying')"></span>
+                            :class="{'opacity-50 cursor-not-allowed': applyingEntityId || renamingDevice}">
+                        <i class="ri-check-double-line mr-2"></i>
+                        <span x-text="t('action_bar.apply_all')">Apply All Changes</span>
                     </button>
                 </div>
             </div>
@@ -2151,6 +2149,76 @@
                 <button @click="message = ''" class="ml-4 opacity-70 hover:opacity-100">
                     <i class="ri-close-line"></i>
                 </button>
+            </div>
+        </div>
+
+        <!-- Background Job Progress Panel -->
+        <div x-cloak
+             x-show="jobPanel.show"
+             x-transition:enter="transition ease-out duration-200"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+            <div class="bg-white rounded-xl shadow-xl max-w-lg w-full"
+                 x-transition:enter="transition ease-out duration-200"
+                 x-transition:enter-start="opacity-0 scale-95"
+                 x-transition:enter-end="opacity-100 scale-100">
+                <div class="p-6">
+                    <div class="flex items-center gap-3 mb-4">
+                        <div class="w-10 h-10 rounded-full flex items-center justify-center"
+                             :class="isJobTerminal(jobPanel.job) ? (jobFailed(jobPanel.job) ? 'bg-red-100' : 'bg-green-100') : 'bg-blue-100'">
+                            <i class="text-xl"
+                               :class="!isJobTerminal(jobPanel.job) ? 'ri-loader-4-line animate-spin text-blue-600' : (jobFailed(jobPanel.job) ? 'ri-error-warning-line text-red-600' : 'ri-check-line text-green-600')"></i>
+                        </div>
+                        <h3 class="text-lg font-semibold" x-text="jobPanel.titleKey ? t(jobPanel.titleKey) : t('jobs.working')"></h3>
+                    </div>
+
+                    <!-- Progress bar (shown while a total is known) -->
+                    <template x-if="jobPanel.job && jobPanel.job.progress && jobPanel.job.progress.total > 0">
+                        <div class="mb-3">
+                            <div class="flex justify-between text-sm text-gray-500 mb-1">
+                                <span x-text="`${jobPanel.job.progress.done}/${jobPanel.job.progress.total}`"></span>
+                                <span x-text="`${jobProgressPercent()}%`"></span>
+                            </div>
+                            <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                                <div class="h-full bg-blue-600 transition-all duration-300"
+                                     :style="`width: ${jobProgressPercent()}%`"></div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <!-- Current item / final message -->
+                    <p class="text-sm text-gray-600 mb-3 truncate"
+                       x-text="isJobTerminal(jobPanel.job) ? (jobFailed(jobPanel.job) ? (jobPanel.job.error || t('jobs.failed')) : ((jobPanel.job.result && jobPanel.job.result.message) || t('jobs.completed'))) : (jobPanel.job && jobPanel.job.progress && jobPanel.job.progress.current) || t('jobs.working')"></p>
+
+                    <!-- Collapsible, height-limited log tail -->
+                    <template x-if="jobPanel.job && jobPanel.job.log && jobPanel.job.log.length">
+                        <div class="mb-2">
+                            <button @click="jobPanel.showLog = !jobPanel.showLog"
+                                    class="text-xs text-gray-500 hover:text-gray-700 flex items-center gap-1">
+                                <i :class="jobPanel.showLog ? 'ri-arrow-down-s-line' : 'ri-arrow-right-s-line'"></i>
+                                <span x-text="jobPanel.showLog ? t('jobs.hide_log') : t('jobs.show_log')"></span>
+                            </button>
+                            <div x-show="jobPanel.showLog"
+                                 class="mt-2 max-h-40 overflow-y-auto text-xs font-mono bg-gray-50 rounded p-2 border border-gray-200">
+                                <template x-for="(entry, i) in jobPanel.job.log.slice(-100)" :key="i">
+                                    <div class="text-gray-600 truncate">
+                                        <span class="text-gray-400" x-text="entry.step"></span>
+                                        <span x-text="' ' + entry.message"></span>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+
+                    <div class="flex justify-end mt-4">
+                        <button @click="closeJobPanel()"
+                                :disabled="!isJobTerminal(jobPanel.job)"
+                                class="btn"
+                                :class="isJobTerminal(jobPanel.job) ? 'btn-primary' : 'btn-ghost opacity-50 cursor-not-allowed'"
+                                x-text="isJobTerminal(jobPanel.job) ? t('jobs.close') : t('jobs.running')"></button>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -2412,6 +2480,19 @@
                             <p class="text-base font-semibold text-gray-900" x-text="swap.busy ? 'Austausch läuft…' : swap.job?.state==='COMPLETED' ? 'Austausch abgeschlossen' : swap.job?.state==='FAILED' ? 'Austausch fehlgeschlagen' : ''"></p>
                             <p x-show="!swap.busy && swap.job?.state==='FAILED'" class="text-sm text-gray-500 mt-1">Fehlgeschlagen bei Schritt <span class="font-medium" x-text="swap.job?.failed_step"></span>. „Erneut versuchen" setzt fort.</p>
                         </div>
+                        <!-- Live entity-rename progress while the swap runs -->
+                        <template x-if="swap.busy && swap.job?.progress && swap.job.progress.total > 0">
+                            <div class="mb-3">
+                                <div class="flex justify-between text-xs text-gray-500 mb-1">
+                                    <span x-text="`${swap.job.progress.done}/${swap.job.progress.total}`"></span>
+                                    <span x-text="`${Math.min(100, Math.round(swap.job.progress.done / swap.job.progress.total * 100))}%`"></span>
+                                </div>
+                                <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                                    <div class="h-full bg-blue-600 transition-all duration-300"
+                                         :style="`width: ${Math.min(100, Math.round(swap.job.progress.done / swap.job.progress.total * 100))}%`"></div>
+                                </div>
+                            </div>
+                        </template>
                         <!-- Natives Entfernen scheiterte (Teilerfolg) -->
                         <div x-show="swap.job?.native_remove_warning" class="rounded-lg border border-amber-200 bg-amber-50 p-3 mb-3">
                             <div class="flex items-start gap-2">
@@ -2479,11 +2560,20 @@
             return {
                 // State
                 loading: false,
-                executing: false,
-                executingProgress: 0,
-                executingTotal: 0,
                 message: '',
                 messageType: 'success',
+
+                // Generic background-job progress panel (rename/execute/enable/swap)
+                jobPanel: {
+                    show: false,
+                    kind: null,       // 'rename_device' | 'execute' | 'enable_all' | 'swap'
+                    titleKey: '',     // translation key, rendered reactively via t()
+                    pollUrl: null,
+                    job: null,
+                    showLog: false,   // log tail is collapsed by default
+                    timer: null,
+                    onDone: null,
+                },
 
                 // Hierarchy data
                 hierarchy: {
@@ -2528,6 +2618,7 @@
                     step: 1,            // 1=Geräte, 2=Mapping, 3=Vorschau, 4=Ausführung
                     loading: false,
                     busy: false,
+                    timer: null,        // polling handle while the swap executes
                     devices: [],
                     resumeJobs: [],
                     oldId: '',
@@ -2637,6 +2728,7 @@
                 },
 
                 closeSwap() {
+                    this.stopSwapPolling();
                     this.swap.show = false;
                 },
 
@@ -2715,20 +2807,43 @@
                             body: JSON.stringify({ entity_mapping: pairs, old_device_disposition: this.swap.disposition })
                         });
                         const cj = await c.json();
-                        if (!c.ok) throw new Error(cj.error || 'Bestätigung fehlgeschlagen');
+                        if (!c.ok) throw new Error(cj.error || 'Confirmation failed');
                         this.swap.step = 4;
+                        // Execute now returns 202 immediately; poll api/swap/<id> for progress.
                         const e = await fetch(`api/swap/${this.swap.job.job_id}/execute`, { method: 'POST' });
                         const ej = await e.json();
-                        if (!e.ok) throw new Error(ej.error || 'Ausführung fehlgeschlagen');
+                        if (!e.ok) throw new Error(ej.error || 'Execution failed');
                         this.swap.job = ej;
-                        if (ej.state === 'COMPLETED') {
-                            this.showMessage('Geräte-Austausch abgeschlossen', 'success');
-                        }
+                        this.startSwapPolling();
                     } catch (e) {
                         this.swap.error = e.message;
-                    } finally {
                         this.swap.busy = false;
                     }
+                },
+
+                startSwapPolling() {
+                    this.stopSwapPolling();
+                    this.swap.busy = true;
+                    this.swap.timer = setInterval(() => this.pollSwap(), 1000);
+                },
+
+                async pollSwap() {
+                    if (!this.swap.job) return;
+                    try {
+                        const j = await fetch(`api/swap/${this.swap.job.job_id}`).then(r => r.json());
+                        if (!j || j.error) return;  // transient; keep polling
+                        this.swap.job = j;
+                        if (['COMPLETED', 'ABORTED', 'FAILED'].includes(j.state)) {
+                            this.stopSwapPolling();
+                            if (j.state === 'COMPLETED') this.showMessage('Device swap completed', 'success');
+                            else if (j.state === 'FAILED') this.showMessage('Device swap failed', 'error');
+                        }
+                    } catch (e) { /* keep polling */ }
+                },
+
+                stopSwapPolling() {
+                    if (this.swap.timer) { clearInterval(this.swap.timer); this.swap.timer = null; }
+                    this.swap.busy = false;
                 },
 
                 async swapResume(jobId) {
@@ -2760,17 +2875,16 @@
                         } else if (j.state === 'COMPLETED' || j.state === 'ABORTED') {
                             this.swap.step = 4;
                         } else {
-                            // mitten in der Ausführung oder FAILED -> fortsetzen
+                            // mid-execution or FAILED -> resume (202 + poll)
                             this.swap.step = 4;
-                            this.swap.busy = true;
                             const e = await fetch(`api/swap/${jobId}/execute`, { method: 'POST' });
                             const ej = await e.json();
-                            if (!e.ok) throw new Error(ej.error || 'Fortsetzen fehlgeschlagen');
+                            if (!e.ok) throw new Error(ej.error || 'Resume failed');
                             this.swap.job = ej;
+                            this.startSwapPolling();
                         }
                     } catch (e) {
                         this.swap.error = e.message;
-                    } finally {
                         this.swap.busy = false;
                     }
                 },
@@ -3143,42 +3257,38 @@
                 async enableAllDisabled() {
                     const disabledEntities = this.filteredEntities.filter(e => e.disabled_by);
                     if (disabledEntities.length === 0) return;
+                    const ids = disabledEntities.map(e => e.id);
 
-                    this.executing = true;
-                    this.executingProgress = 0;
-                    this.executingTotal = disabledEntities.length;
-                    let successCount = 0;
-                    let failedCount = 0;
-
-                    for (let i = 0; i < disabledEntities.length; i++) {
-                        const entity = disabledEntities[i];
-                        try {
-                            const response = await fetch('api/enable_entity', {
-                                method: 'POST',
-                                headers: {'Content-Type': 'application/json'},
-                                body: JSON.stringify({ entity_id: entity.id })
-                            });
-                            const data = await response.json();
-                            if (data.success) {
-                                entity.disabled_by = null;
-                                successCount++;
-                            } else {
-                                failedCount++;
-                            }
-                        } catch (error) {
-                            failedCount++;
+                    try {
+                        // Enqueue enabling the whole batch as one background job.
+                        const response = await fetch('api/enable_all', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({ entity_ids: ids })
+                        });
+                        const job = await response.json();
+                        if (!response.ok || !job.job_id) {
+                            throw new Error(job.error || 'Failed to start enable');
                         }
-                        this.executingProgress = i + 1;
+                        this.startJob('api/jobs/' + job.job_id, job, {
+                            kind: 'enable_all',
+                            titleKey: 'jobs.enabling',
+                            onDone: (finished) => this.onEnableAllDone(finished)
+                        });
+                    } catch (error) {
+                        this.showMessage('Error: ' + error.message, 'error');
                     }
+                },
 
-                    this.executing = false;
-                    this.executingProgress = 0;
-                    this.executingTotal = 0;
-                    if (failedCount > 0) {
-                        this.showMessage(`${successCount} enabled, ${failedCount} failed`, 'error');
-                    } else {
-                        this.showMessage(`${successCount} entities enabled`, 'success');
+                async onEnableAllDone(job) {
+                    if (!this.jobFailed(job)) {
+                        const r = job.result || {};
+                        const successCount = (r.enabled || []).length;
+                        const failedCount = (r.failed || []).length;
+                        if (failedCount > 0) this.showMessage(`${successCount} enabled, ${failedCount} failed`, 'error', true);
+                        else this.showMessage(`${successCount} entities enabled`, 'success', true);
                     }
+                    await this.loadHierarchy();
                 },
 
                 // Initialize
@@ -3197,6 +3307,11 @@
                             this.translationsReady = true;
                         }
                     }
+
+                    // Re-attach to a background job still running from before a reload,
+                    // before (and independently of) the hierarchy load, so the progress
+                    // modal reappears immediately even while data is still loading.
+                    this.reconnectJobs();
 
                     // Load hierarchy
                     await this.loadHierarchy();
@@ -4559,6 +4674,127 @@
                 },
 
                 // Rename device directly in HA
+                // === Generic background-job progress panel ===
+                // Long-running operations (device rename, batch apply, enable-all,
+                // swap) run as a server-side job. The frontend starts the job,
+                // opens this panel and polls until the job reaches a terminal
+                // state, then runs the kind-specific onDone handler.
+                startJob(pollUrl, job, { kind = null, titleKey = '', onDone = null } = {}) {
+                    this.stopJobPolling();
+                    this.jobPanel.pollUrl = pollUrl;
+                    this.jobPanel.job = job;
+                    this.jobPanel.kind = kind;
+                    this.jobPanel.titleKey = titleKey;
+                    this.jobPanel.onDone = onDone;
+                    this.jobPanel.showLog = false;
+                    this.jobPanel.show = true;
+                    if (this.isJobTerminal(job)) {
+                        this.finishJob();
+                    } else {
+                        this.jobPanel.timer = setInterval(() => this.pollJob(), 1000);
+                    }
+                },
+
+                async pollJob() {
+                    if (!this.jobPanel.pollUrl) return;
+                    try {
+                        const r = await fetch(this.jobPanel.pollUrl);
+                        if (!r.ok) return;  // transient (e.g. brief write race); keep polling
+                        const job = await r.json();
+                        this.jobPanel.job = job;
+                        if (this.isJobTerminal(job)) this.finishJob();
+                    } catch (e) {
+                        // transient network error; keep polling
+                    }
+                },
+
+                async finishJob() {
+                    this.stopJobPolling();
+                    const finished = this.jobPanel.job;
+                    const cb = this.jobPanel.onDone;
+                    // Success (job not hard-failed): close the panel immediately; the
+                    // onDone handler surfaces a self-dismissing toast and refreshes in
+                    // the background. Hard failure: keep the panel open so the error
+                    // stays visible (no toast — the panel already shows it).
+                    if (finished && !this.jobFailed(finished)) this.closeJobPanel();
+                    if (cb) await cb(finished);
+                },
+
+                stopJobPolling() {
+                    if (this.jobPanel.timer) { clearInterval(this.jobPanel.timer); this.jobPanel.timer = null; }
+                },
+
+                closeJobPanel() {
+                    this.stopJobPolling();
+                    this.jobPanel.show = false;
+                    this.jobPanel.job = null;
+                    this.jobPanel.pollUrl = null;
+                    this.jobPanel.onDone = null;
+                },
+
+                isJobTerminal(job) {
+                    // Generic jobs use lowercase states; swap jobs reuse this panel
+                    // via api/swap/<id> and use uppercase state names.
+                    return !!job && ['completed', 'failed', 'COMPLETED', 'FAILED', 'ABORTED'].includes(job.state);
+                },
+
+                jobFailed(job) {
+                    return !!job && ['failed', 'FAILED'].includes(job.state);
+                },
+
+                jobProgressPercent() {
+                    const p = this.jobPanel.job && this.jobPanel.job.progress;
+                    if (!p || !p.total) return 0;
+                    return Math.min(100, Math.round((p.done / p.total) * 100));
+                },
+
+                // True while a blocking background job is running (its panel is open
+                // and not yet terminal). Action buttons disable on this.
+                get executing() {
+                    return this.jobPanel.show && !this.isJobTerminal(this.jobPanel.job);
+                },
+
+                // On page load, re-attach to a still-running generic job (survives reload).
+                async reconnectJobs() {
+                    try {
+                        const data = await fetch('api/jobs').then(r => r.json()).catch(() => ({ jobs: [] }));
+                        const running = (data.jobs || []).find(j => !this.isJobTerminal(j));
+                        if (!running) return;
+                        const meta = this.jobKindMeta(running.type);
+                        this.startJob('api/jobs/' + running.job_id, running, {
+                            kind: running.type, titleKey: meta.titleKey, onDone: meta.onDone
+                        });
+                    } catch (e) { /* ignore */ }
+                },
+
+                // Reconstruct a reconnected job's title + completion handler from its type.
+                jobKindMeta(type) {
+                    if (type === 'rename_device') {
+                        return { titleKey: 'jobs.rename_device', onDone: (job) => this.onRenameDeviceDone(job) };
+                    }
+                    if (type === 'execute' || type === 'execute_direct') {
+                        return { titleKey: 'jobs.applying', onDone: (job) => this.onExecuteDone(job) };
+                    }
+                    if (type === 'enable_all') {
+                        return { titleKey: 'jobs.enabling', onDone: (job) => this.onEnableAllDone(job) };
+                    }
+                    return { titleKey: 'jobs.working', onDone: null };
+                },
+
+                async onRenameDeviceDone(job, deviceId = null) {
+                    if (!this.jobFailed(job)) {
+                        const r = job.result || {};
+                        this.showMessage(r.message || 'Device renamed', (r.entities_failed > 0) ? 'error' : 'success', true);
+                    }
+                    this.devicePreviewBaseName = null;
+                    await this.loadHierarchy();
+                    const id = deviceId || this.selectedDevice;
+                    if (id) {
+                        const updated = this.hierarchy.devices.find(d => d.id === id);
+                        if (updated) this.selectedDeviceData = updated;
+                    }
+                },
+
                 async renameDeviceInHA(newBaseName) {
                     if (!this.selectedDevice || this.isVirtualDevice(this.selectedDevice) || !newBaseName || this.renamingDevice) return;
 
@@ -4580,7 +4816,7 @@
 
                     this.renamingDevice = true;
                     try {
-                        // Rename the device directly in HA
+                        // Enqueue the rename as a background job (returns 202 + job).
                         const response = await fetch('api/rename_device', {
                             method: 'POST',
                             headers: {'Content-Type': 'application/json'},
@@ -4589,35 +4825,20 @@
                                 new_name: newFullName
                             })
                         });
-
-                        const data = await response.json();
-                        if (data.success) {
-                            this.devicePreviewBaseName = null;  // Clear preview after successful rename
-
-                            // Show success message with entity count
-                            const entityCount = data.entities_updated || 0;
-                            const depCount = data.dependencies_updated || 0;
-                            let msg = `Device renamed to "${newFullName}"`;
-                            if (entityCount > 0) msg += ` (${entityCount} entities`;
-                            if (depCount > 0) msg += `, ${depCount} dependencies`;
-                            if (entityCount > 0) msg += ')';
-                            this.showMessage(msg, 'success');
-
-                            // Wait for HA to persist changes, then reload
-                            await new Promise(resolve => setTimeout(resolve, 500));
-                            const deviceId = this.selectedDevice;  // Keep device ID before reload
-                            await this.loadHierarchy();
-
-                            // Re-select the device from the new hierarchy data
-                            if (deviceId) {
-                                const updatedDevice = this.hierarchy.devices.find(d => d.id === deviceId);
-                                if (updatedDevice) {
-                                    this.selectedDeviceData = updatedDevice;
-                                }
-                            }
-                        } else {
-                            throw new Error(data.error || 'Failed to rename device');
+                        const job = await response.json();
+                        if (response.status === 409) {
+                            this.showMessage(job.error || 'A rename for this device is already in progress', 'error');
+                            return;
                         }
+                        if (!response.ok || !job.job_id) {
+                            throw new Error(job.error || 'Failed to start device rename');
+                        }
+                        const deviceId = this.selectedDevice;  // keep before any reload
+                        this.startJob('api/jobs/' + job.job_id, job, {
+                            kind: 'rename_device',
+                            titleKey: 'jobs.rename_device',
+                            onDone: (finished) => this.onRenameDeviceDone(finished, deviceId)
+                        });
                     } catch (error) {
                         this.showMessage('Error: ' + error.message, 'error');
                     } finally {
@@ -4692,105 +4913,98 @@
                 async executeAllChanges() {
                     // Find all entities that need renaming
                     const entitiesToChange = this.filteredEntities.filter(e => this.entityNeedsRename(e));
-                    // Z2M-Geräte im aktuellen View, deren Z2M-Name vom HA-Namen abweicht
+                    // Z2M devices in the current view whose Z2M name drifted from the HA name
                     const z2mDriftDevices = this.filteredDevices.filter(d => d.z2m_drift);
                     if (entitiesToChange.length === 0 && z2mDriftDevices.length === 0) {
                         this.showMessage('No changes to apply', 'info');
                         return;
                     }
 
-                    this.executing = true;
-                    this.executingProgress = 0;
-                    this.executingTotal = entitiesToChange.length + z2mDriftDevices.length;
+                    // Build the payload with entity details
+                    const allEntities = entitiesToChange.map(e => ({
+                        old_id: e.id,
+                        new_id: e._previewId || this.getNewEntityIdForEntity(e),
+                        new_name: e._previewName || this.getEntityFriendlyNameForEntity(e),
+                        registry_id: e.registry_id
+                    }));
+                    // Capture drift device ids so the completion handler can sync them after.
+                    const driftDevices = z2mDriftDevices.map(d => d.id);
 
-                    // Batch size - process 10 entities at a time to avoid timeouts
-                    const BATCH_SIZE = 10;
-                    const results = { success: [], failed: [], skipped: [] };
+                    // Only Z2M drift to fix, no entity renames: run it directly (fast).
+                    if (allEntities.length === 0) {
+                        const z = await this.syncZ2mDrift(driftDevices);
+                        if (z.failed > 0) this.showMessage(`${z.failed} Z2M failed`, 'error');
+                        else if (z.synced > 0) this.showMessage(`${z.synced} Z2M synced`, 'success');
+                        await this.loadHierarchy();
+                        return;
+                    }
 
                     try {
-                        // Build the payload with entity details
-                        const allEntities = entitiesToChange.map(e => ({
-                            old_id: e.id,
-                            new_id: e._previewId || this.getNewEntityIdForEntity(e),
-                            new_name: e._previewName || this.getEntityFriendlyNameForEntity(e),
-                            registry_id: e.registry_id
-                        }));
-
-                        // Process in batches
-                        for (let i = 0; i < allEntities.length; i += BATCH_SIZE) {
-                            const batch = allEntities.slice(i, i + BATCH_SIZE);
-
-                            try {
-                                const response = await fetch('api/execute_direct', {
-                                    method: 'POST',
-                                    headers: {'Content-Type': 'application/json'},
-                                    body: JSON.stringify({ entities: batch })
-                                });
-
-                                if (!response.ok) {
-                                    // Server error - mark all in batch as failed
-                                    batch.forEach(e => results.failed.push({ entity_id: e.old_id, error: `HTTP ${response.status}` }));
-                                } else {
-                                    const data = await response.json();
-                                    results.success.push(...(data.success || []));
-                                    results.failed.push(...(data.failed || []));
-                                    results.skipped.push(...(data.skipped || []));
-                                }
-                            } catch (batchError) {
-                                // Network error - mark all in batch as failed
-                                batch.forEach(e => results.failed.push({ entity_id: e.old_id, error: batchError.message }));
-                            }
-
-                            // Update progress
-                            this.executingProgress = Math.min(i + BATCH_SIZE, allEntities.length);
+                        // Enqueue the whole batch as one background job.
+                        const response = await fetch('api/execute_direct', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({ entities: allEntities })
+                        });
+                        const job = await response.json();
+                        if (!response.ok || !job.job_id) {
+                            throw new Error(job.error || 'Failed to start apply');
                         }
-
-                        // Z2M-Namen der driftenden Geräte nachziehen (nach den Entity-Renames)
-                        let z2mSynced = 0, z2mFailed = 0;
-                        for (const dev of z2mDriftDevices) {
-                            try {
-                                const resp = await fetch('api/sync_z2m_name', {
-                                    method: 'POST',
-                                    headers: {'Content-Type': 'application/json'},
-                                    body: JSON.stringify({ device_id: dev.id })
-                                });
-                                const d = await resp.json();
-                                if (resp.ok && d.success) z2mSynced++; else z2mFailed++;
-                            } catch (e) { z2mFailed++; }
-                            this.executingProgress = Math.min(this.executingProgress + 1, this.executingTotal);
-                        }
-
-                        const successCount = results.success.length;
-                        const failedCount = results.failed.length;
-
-                        if (failedCount > 0 || z2mFailed > 0) {
-                            this.showMessage(`${successCount} succeeded, ${failedCount} failed` + (z2mFailed ? `, ${z2mFailed} Z2M failed` : ''), 'error');
-                        } else if (successCount > 0 || z2mSynced > 0) {
-                            this.showMessage(`${successCount} entities renamed` + (z2mSynced ? `, ${z2mSynced} Z2M synced` : ''), 'success');
-                        }
-
-                        // Wait a moment for HA to persist changes before reload
-                        await new Promise(resolve => setTimeout(resolve, 1000));
-
-                        // Reload to show updated state
-                        await this.loadHierarchy();
+                        this.startJob('api/jobs/' + job.job_id, job, {
+                            kind: 'execute_direct',
+                            titleKey: 'jobs.applying',
+                            onDone: (finished) => this.onExecuteDone(finished, driftDevices)
+                        });
                     } catch (error) {
                         this.showMessage('Error: ' + error.message, 'error');
-                    } finally {
-                        this.executing = false;
-                        this.executingProgress = 0;
-                        this.executingTotal = 0;
                     }
                 },
 
+                async onExecuteDone(job, driftDevices = []) {
+                    if (!this.jobFailed(job)) {
+                        const r = job.result || {};
+                        const successCount = (r.success || []).length;
+                        const failedCount = (r.failed || []).length;
+                        // Sync drifting Z2M names after the entity renames.
+                        const z = await this.syncZ2mDrift(driftDevices);
+                        if (failedCount > 0 || z.failed > 0) {
+                            this.showMessage(`${successCount} succeeded, ${failedCount} failed` + (z.failed ? `, ${z.failed} Z2M failed` : ''), 'error', true);
+                        } else if (successCount > 0 || z.synced > 0) {
+                            this.showMessage(`${successCount} entities renamed` + (z.synced ? `, ${z.synced} Z2M synced` : ''), 'success', true);
+                        }
+                    }
+                    await this.loadHierarchy();
+                },
+
+                async syncZ2mDrift(deviceIds) {
+                    let synced = 0, failed = 0;
+                    for (const id of deviceIds || []) {
+                        try {
+                            const resp = await fetch('api/sync_z2m_name', {
+                                method: 'POST',
+                                headers: {'Content-Type': 'application/json'},
+                                body: JSON.stringify({ device_id: id })
+                            });
+                            const d = await resp.json();
+                            if (resp.ok && d.success) synced++; else failed++;
+                        } catch (e) { failed++; }
+                    }
+                    return { synced, failed };
+                },
+
                 // Show message
-                showMessage(msg, type = 'success') {
-                    // Only show error/warning messages, not success
-                    if (type === 'success' || type === 'info') return;
+                showMessage(msg, type = 'success', force = false) {
+                    // Success/info are normally suppressed (only errors/warnings surface);
+                    // force=true lets deliberate confirmations (e.g. a finished job) show.
+                    if ((type === 'success' || type === 'info') && !force) return;
 
                     this.message = msg;
                     this.messageType = type;
-                    // Errors must be manually dismissed - no auto-close
+                    // Errors stay until manually dismissed; success/info auto-dismiss.
+                    clearTimeout(this._msgTimer);
+                    if (type !== 'error') {
+                        this._msgTimer = setTimeout(() => { this.message = ''; }, 4000);
+                    }
                 }
             };
         }

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,207 @@
+"""Tests for the generic background-job infrastructure (store, context, worker)."""
+
+import threading
+
+import jobs
+from jobs import STATE_COMPLETED, STATE_FAILED, STATE_QUEUED, STATE_RUNNING, JobContext, JobStore, JobWorker, new_job
+
+TERMINAL = {STATE_COMPLETED, STATE_FAILED}
+
+
+def _store(tmp_path):
+    return JobStore(str(tmp_path), terminal_states=TERMINAL)
+
+
+# --------------------------------------------------------------------------- #
+# JobStore
+# --------------------------------------------------------------------------- #
+
+
+def test_store_save_load_roundtrip(tmp_path):
+    store = _store(tmp_path)
+    job = new_job("rename_device", {"device_id": "abc"}, job_id="j1")
+    store.save(job)
+    loaded = store.load("j1")
+    assert loaded["job_id"] == "j1"
+    assert loaded["type"] == "rename_device"
+    assert loaded["payload"] == {"device_id": "abc"}
+    assert loaded["version"] == store.schema_version
+
+
+def test_store_load_missing_returns_none(tmp_path):
+    assert _store(tmp_path).load("nope") is None
+
+
+def test_store_list_unfinished_filters_terminal(tmp_path):
+    store = _store(tmp_path)
+    store.save(new_job("t", {}, job_id="running") | {"state": STATE_RUNNING})
+    store.save(new_job("t", {}, job_id="done") | {"state": STATE_COMPLETED})
+    store.save(new_job("t", {}, job_id="failed") | {"state": STATE_FAILED})
+    ids = {j["job_id"] for j in store.list_unfinished()}
+    assert ids == {"running"}
+
+
+def test_store_skips_unreadable_file(tmp_path):
+    store = _store(tmp_path)
+    store.save(new_job("t", {}, job_id="good"))
+    (tmp_path / "broken.json").write_text("{ not json", encoding="utf-8")
+    ids = {j["job_id"] for j in store.list_jobs()}
+    assert ids == {"good"}
+
+
+def test_store_delete(tmp_path):
+    store = _store(tmp_path)
+    store.save(new_job("t", {}, job_id="j"))
+    store.delete("j")
+    assert store.load("j") is None
+    store.delete("j")  # deleting a missing job is a no-op
+
+
+def test_store_atomic_write_leaves_no_tmp(tmp_path):
+    store = _store(tmp_path)
+    store.save(new_job("t", {}, job_id="j"))
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+# --------------------------------------------------------------------------- #
+# JobContext.progress throttling
+# --------------------------------------------------------------------------- #
+
+
+def test_progress_throttles_saves(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    job = new_job("t", {}, job_id="j")
+    store.save(job)
+
+    saves = {"n": 0}
+    original = store.save
+    store.save = lambda j: (saves.__setitem__("n", saves["n"] + 1), original(j))[1]
+
+    clock = {"t": 100.0}
+    monkeypatch.setattr(jobs.time, "monotonic", lambda: clock["t"])
+
+    ctx = JobContext(job, store, throttle_seconds=0.5)
+    ctx.progress(1, 10)  # first call: last_save is 0.0 -> writes
+    ctx.progress(2, 10)  # same clock, within throttle -> skipped
+    clock["t"] += 1.0
+    ctx.progress(3, 10)  # throttle elapsed -> writes
+    ctx.progress(10, 10)  # done >= total -> always writes
+    assert saves["n"] == 3
+    assert store.load("j")["progress"] == {"done": 10, "total": 10, "current": ""}
+
+
+def test_log_persists_every_line(tmp_path):
+    store = _store(tmp_path)
+    job = new_job("t", {}, job_id="j")
+    store.save(job)
+    ctx = JobContext(job, store)
+    ctx.log("STEP", "hello")
+    ctx.log("STEP", "world")
+    log = store.load("j")["log"]
+    assert [entry["message"] for entry in log] == ["hello", "world"]
+    assert all("ts" in entry for entry in log)
+
+
+# --------------------------------------------------------------------------- #
+# JobWorker
+# --------------------------------------------------------------------------- #
+
+
+def _worker(tmp_path):
+    store = _store(tmp_path)
+    worker = JobWorker(store)
+    return store, worker
+
+
+def test_worker_runs_handler_to_completion(tmp_path):
+    store, worker = _worker(tmp_path)
+
+    async def handler(job, ctx):
+        ctx.progress(1, 1, current="x")
+        return {"ok": True, "device": job["payload"]["device_id"]}
+
+    worker.register("demo", handler)
+    worker.start()
+    job = new_job("demo", {"device_id": "d1"}, job_id="j")
+    store.save(job)
+    worker.enqueue(job)
+    worker.queue.join()
+
+    done = store.load("j")
+    assert done["state"] == STATE_COMPLETED
+    assert done["result"] == {"ok": True, "device": "d1"}
+    assert done["progress"] == {"done": 1, "total": 1, "current": "x"}
+
+
+def test_worker_marks_failure(tmp_path):
+    store, worker = _worker(tmp_path)
+
+    async def handler(job, ctx):
+        raise ValueError("boom")
+
+    worker.register("demo", handler)
+    worker.start()
+    job = new_job("demo", {}, job_id="j")
+    store.save(job)
+    worker.enqueue(job)
+    worker.queue.join()
+
+    done = store.load("j")
+    assert done["state"] == STATE_FAILED
+    assert done["error"] == "boom"
+    assert done["log"][-1]["message"] == "boom"
+
+
+def test_worker_unknown_type_fails_job(tmp_path):
+    store, worker = _worker(tmp_path)
+    worker.start()
+    job = new_job("mystery", {}, job_id="j")
+    store.save(job)
+    worker.enqueue(job)
+    worker.queue.join()
+
+    done = store.load("j")
+    assert done["state"] == STATE_FAILED
+    assert "No handler" in done["error"]
+
+
+def test_worker_runs_jobs_serially(tmp_path):
+    store, worker = _worker(tmp_path)
+    concurrent = {"max": 0, "cur": 0}
+    guard = threading.Lock()
+
+    async def handler(job, ctx):
+        with guard:
+            concurrent["cur"] += 1
+            concurrent["max"] = max(concurrent["max"], concurrent["cur"])
+        with guard:
+            concurrent["cur"] -= 1
+        return None
+
+    worker.register("demo", handler)
+    worker.start()
+    for i in range(5):
+        job = new_job("demo", {}, job_id=f"j{i}")
+        store.save(job)
+        worker.enqueue(job)
+    worker.queue.join()
+    assert concurrent["max"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# reconcile_on_start
+# --------------------------------------------------------------------------- #
+
+
+def test_reconcile_fails_interrupted_jobs(tmp_path):
+    store = _store(tmp_path)
+    store.save(new_job("t", {}, job_id="queued") | {"state": STATE_QUEUED})
+    store.save(new_job("t", {}, job_id="running") | {"state": STATE_RUNNING})
+    store.save(new_job("t", {}, job_id="done") | {"state": STATE_COMPLETED})
+
+    JobWorker(store).reconcile_on_start()
+
+    assert store.load("queued")["state"] == STATE_FAILED
+    assert store.load("running")["state"] == STATE_FAILED
+    assert store.load("running")["error"] == "Interrupted by restart"
+    assert store.load("done")["state"] == STATE_COMPLETED

--- a/tests/test_web_rename_job.py
+++ b/tests/test_web_rename_job.py
@@ -1,0 +1,52 @@
+"""Tests for the async rename_device endpoint (request-thread path only).
+
+These verify that the request thread validates, sanitizes and enqueues the job
+(and copies the payload, since the worker thread has no request context) without
+touching Home Assistant. The worker is not started, so enqueued jobs stay queued.
+"""
+
+import pytest
+
+from jobs import TERMINAL_STATES, JobStore, JobWorker
+import web_ui
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    store = JobStore(str(tmp_path), terminal_states=TERMINAL_STATES)
+    monkeypatch.setitem(web_ui.renamer_state, "job_store", store)
+    monkeypatch.setitem(web_ui.renamer_state, "worker", JobWorker(store))
+    web_ui.app.config["TESTING"] = True
+    return web_ui.app.test_client(), store
+
+
+def test_rename_device_enqueues_job(client):
+    c, store = client
+    resp = c.post("/api/rename_device", json={"device_id": "dev1", "new_name": "Kitchen Light"})
+    assert resp.status_code == 202
+    body = resp.get_json()
+    assert body["type"] == "rename_device"
+    assert body["state"] == "queued"
+    assert store.load(body["job_id"])["payload"] == {"device_id": "dev1", "new_name": "Kitchen Light"}
+
+
+def test_rename_device_missing_field_is_400(client):
+    c, _ = client
+    resp = c.post("/api/rename_device", json={"device_id": "dev1"})
+    assert resp.status_code == 400
+
+
+def test_rename_device_duplicate_device_is_409(client):
+    c, _ = client
+    assert c.post("/api/rename_device", json={"device_id": "dev1", "new_name": "A"}).status_code == 202
+    dup = c.post("/api/rename_device", json={"device_id": "dev1", "new_name": "B"})
+    assert dup.status_code == 409
+
+
+def test_job_get_and_list(client):
+    c, _ = client
+    jid = c.post("/api/rename_device", json={"device_id": "dev1", "new_name": "A"}).get_json()["job_id"]
+    assert c.get(f"/api/jobs/{jid}").get_json()["job_id"] == jid
+    assert c.get("/api/jobs/does-not-exist").status_code == 404
+    listing = c.get("/api/jobs").get_json()["jobs"]
+    assert [j["job_id"] for j in listing] == [jid]

--- a/translations/ui/de.json
+++ b/translations/ui/de.json
@@ -334,5 +334,17 @@
     "update": "Aktualisierung",
     "remote": "Fernbedienung",
     "plant": "Pflanze"
+  },
+  "jobs": {
+    "rename_device": "Gerät wird umbenannt",
+    "applying": "Änderungen werden angewendet",
+    "enabling": "Entitäten werden aktiviert",
+    "working": "Wird ausgeführt",
+    "running": "Läuft…",
+    "completed": "Abgeschlossen",
+    "failed": "Fehlgeschlagen",
+    "close": "Schließen",
+    "show_log": "Log anzeigen",
+    "hide_log": "Log ausblenden"
   }
 }

--- a/translations/ui/en.json
+++ b/translations/ui/en.json
@@ -334,5 +334,17 @@
     "update": "Update",
     "remote": "Remote",
     "plant": "Plant"
+  },
+  "jobs": {
+    "rename_device": "Renaming device",
+    "applying": "Applying changes",
+    "enabling": "Enabling entities",
+    "working": "Working",
+    "running": "Running…",
+    "completed": "Completed",
+    "failed": "Failed",
+    "close": "Close",
+    "show_log": "Show log",
+    "hide_log": "Hide log"
   }
 }

--- a/translations/ui/es.json
+++ b/translations/ui/es.json
@@ -334,5 +334,17 @@
     "api_token_copy": "Copiar",
     "api_token_copied": "¡Copiado!",
     "api_token_revoke_confirm": "¿Revocar el token actual? Las herramientas externas que lo usen dejarán de funcionar."
+  },
+  "jobs": {
+    "rename_device": "Renombrando dispositivo",
+    "applying": "Aplicando cambios",
+    "enabling": "Activando entidades",
+    "working": "Procesando",
+    "running": "En curso…",
+    "completed": "Completado",
+    "failed": "Fallido",
+    "close": "Cerrar",
+    "show_log": "Mostrar registro",
+    "hide_log": "Ocultar registro"
   }
 }

--- a/translations/ui/fr.json
+++ b/translations/ui/fr.json
@@ -334,5 +334,17 @@
     "api_token_copy": "Copier",
     "api_token_copied": "Copié !",
     "api_token_revoke_confirm": "Révoquer le jeton actuel ? Les outils externes qui l'utilisent cesseront de fonctionner."
+  },
+  "jobs": {
+    "rename_device": "Renommage de l'appareil",
+    "applying": "Application des modifications",
+    "enabling": "Activation des entités",
+    "working": "Traitement",
+    "running": "En cours…",
+    "completed": "Terminé",
+    "failed": "Échec",
+    "close": "Fermer",
+    "show_log": "Afficher le journal",
+    "hide_log": "Masquer le journal"
   }
 }

--- a/web_ui.py
+++ b/web_ui.py
@@ -32,6 +32,7 @@ from entity_restructurer import EntityRestructurer
 from ha_client import HomeAssistantClient
 from ha_websocket import HomeAssistantWebSocket
 from hierarchy_manager import normalize_name
+from jobs import TERMINAL_STATES, JobStore, JobWorker, new_job
 from lovelace_updater import LovelaceUpdater
 from naming_overrides import NamingOverrides
 from reference_checker import ReferenceChecker
@@ -163,7 +164,13 @@ renamer_state = {
     "swap_store": SwapJobStore(os.path.join(DATA_DIR, "device_swaps")),
     "rename_log": RenameLog(os.path.join(DATA_DIR, "rename_log.jsonl")),
     "api_token_store": ApiTokenStore(os.path.join(DATA_DIR, "api_token.json")),
+    # Generic background-job infrastructure for long-running operations. Jobs run
+    # serially on a single worker thread; requests keep serving concurrently
+    # (load_structure rebuilds the restructurer by reassignment and handlers work
+    # on snapshots, so no cross-thread lock is needed).
+    "job_store": JobStore(os.path.join(DATA_DIR, "jobs"), terminal_states=TERMINAL_STATES),
 }
+renamer_state["worker"] = JobWorker(renamer_state["job_store"])
 
 # Share the audit log with every EntityRegistry instance so all rename paths
 # (single, batch, device cascade) get recorded centrally.
@@ -1324,24 +1331,33 @@ async def _execute_changes_async():
 
 @app.route("/api/execute_direct", methods=["POST"])
 def execute_direct():
-    """Execute entity renames directly without preview (for hierarchy UI)"""
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(_execute_direct_async())
-    finally:
-        loop.close()
+    """Enqueue a batch entity rename as a background job and return the job.
 
-
-async def _execute_direct_async():
-    """Async implementation of execute_direct"""
-    data = request.json
+    Applying many renames can exceed the Ingress timeout, so the whole batch is
+    handed to the worker and the frontend polls the returned job. The entities
+    payload is read here in the request thread (no request context in the worker).
+    """
+    data = request.json or {}
     entities = data.get("entities", [])
-
     if not entities:
-        return jsonify({"error": "Keine Entities ausgewählt"}), 400
+        return jsonify({"error": "No entities selected"}), 400
 
-    # Execute renaming
+    job = new_job("execute_direct", {"entities": entities}, job_id=uuid.uuid4().hex)
+    renamer_state["job_store"].save(job)
+    renamer_state["worker"].enqueue(job)
+    return jsonify(job), 202
+
+
+async def execute_direct_handler(job, ctx):
+    """Apply a batch of entity renames, reporting progress per entity.
+
+    Runs inside the worker (which holds the registry lock). Renames each entity
+    (id + friendly name), enables disabled ones when configured, and rewrites
+    references in automations/scenes/scripts. Returns the same result shape the
+    endpoint used to return so the UI summary is unchanged.
+    """
+    entities = job["payload"]["entities"]
+
     base_url = os.getenv("HA_URL")
     token = os.getenv("HA_TOKEN")
     ws_url = base_url.replace("https://", "wss://").replace("http://", "ws://") + "/api/websocket"
@@ -1365,13 +1381,17 @@ async def _execute_direct_async():
         cached_states = await dependency_updater.get_states()
         logger.info(f"Cached {len(cached_states)} states")
 
-        for entity_data in entities:
+        total = len(entities)
+        ctx.progress(0, total)
+
+        for index, entity_data in enumerate(entities):
             old_id = entity_data.get("old_id")
             new_id = entity_data.get("new_id")
             friendly_name = entity_data.get("new_name")
 
             if not old_id or not new_id:
                 results["failed"].append({"entity_id": old_id, "error": "Missing old_id or new_id"})
+                ctx.progress(index + 1, total, current=old_id or "")
                 continue
 
             try:
@@ -1383,7 +1403,8 @@ async def _execute_direct_async():
                 id_unchanged = old_id == new_id
                 name_unchanged = friendly_name == current_name
                 if id_unchanged and name_unchanged:
-                    results["skipped"].append({"entity_id": old_id, "reason": "Keine Änderung nötig"})
+                    results["skipped"].append({"entity_id": old_id, "reason": "No change needed"})
+                    ctx.progress(index + 1, total, current=old_id)
                     continue
 
                 # Log what's changing
@@ -1418,14 +1439,18 @@ async def _execute_direct_async():
                     {
                         "old_id": old_id,
                         "new_id": new_id,
-                        "message": f"Entity erfolgreich umbenannt: {old_id} -> {new_id}",
+                        "message": f"Entity renamed successfully: {old_id} -> {new_id}",
                     }
                 )
                 logger.info(f"Successfully renamed: {old_id} -> {new_id}")
+                ctx.log("RENAME", f"{old_id} -> {new_id}")
 
             except Exception as e:
                 logger.error(f"Error renaming entity {old_id}: {e}")
                 results["failed"].append({"entity_id": old_id, "error": str(e)})
+                ctx.log("ERROR", f"{old_id}: {e}")
+
+            ctx.progress(index + 1, total, current=old_id)
 
     finally:
         await ws.disconnect()
@@ -1433,7 +1458,11 @@ async def _execute_direct_async():
     # Invalidate broken references cache after changes
     invalidate_reference_checker_cache()
 
-    return jsonify(results)
+    results["message"] = f"{len(results['success'])} entities renamed"
+    return results
+
+
+renamer_state["worker"].register("execute_direct", execute_direct_handler)
 
 
 @app.route("/api/stats")
@@ -2034,6 +2063,60 @@ async def _enable_entity_async():
         return jsonify({"error": error_msg}), 500
 
 
+@app.route("/api/enable_all", methods=["POST"])
+def enable_all():
+    """Enqueue enabling a batch of disabled entities as a background job.
+
+    Enabling many entities one WS call at a time can exceed the Ingress timeout,
+    so the batch runs in the worker and the frontend polls the returned job.
+    """
+    data = request.json or {}
+    entity_ids = [eid for eid in (sanitize_entity_id(x) for x in data.get("entity_ids", [])) if eid]
+    if not entity_ids:
+        return jsonify({"error": "No entities selected"}), 400
+
+    job = new_job("enable_all", {"entity_ids": entity_ids}, job_id=uuid.uuid4().hex)
+    renamer_state["job_store"].save(job)
+    renamer_state["worker"].enqueue(job)
+    return jsonify(job), 202
+
+
+async def enable_all_handler(job, ctx):
+    """Enable a batch of disabled entities, reporting progress per entity."""
+    entity_ids = job["payload"]["entity_ids"]
+
+    base_url = os.getenv("HA_URL")
+    token = os.getenv("HA_TOKEN")
+    ws_url = base_url.replace("https://", "wss://").replace("http://", "ws://") + "/api/websocket"
+
+    enabled = []
+    failed = []
+    ws = HomeAssistantWebSocket(ws_url, token)
+    await ws.connect()
+    try:
+        entity_registry = EntityRegistry(ws)
+        total = len(entity_ids)
+        ctx.progress(0, total)
+        for index, entity_id in enumerate(entity_ids):
+            try:
+                await entity_registry.update_entity(entity_id=entity_id, enable=True)
+                enabled.append(entity_id)
+                logger.info(f"Enabled entity: {entity_id}")
+                ctx.log("ENABLE", entity_id)
+            except Exception as e:
+                logger.error(f"Error enabling entity {entity_id}: {e}")
+                failed.append({"entity_id": entity_id, "error": str(e)})
+                ctx.log("ERROR", f"{entity_id}: {e}")
+            ctx.progress(index + 1, total, current=entity_id)
+    finally:
+        await ws.disconnect()
+
+    return {"enabled": enabled, "failed": failed, "message": f"{len(enabled)} entities enabled"}
+
+
+renamer_state["worker"].register("enable_all", enable_all_handler)
+
+
 @app.route("/api/enable_device", methods=["POST"])
 def enable_device():
     """Enable a disabled device"""
@@ -2352,21 +2435,12 @@ async def _delete_entity_async():
 
 @app.route("/api/rename_device", methods=["POST"])
 def rename_device():
-    """Benennt ein Gerät in Home Assistant um und aktualisiert Entity-Namen"""
-    # Create new event loop for this request
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(_rename_device_async())
-    finally:
-        loop.close()
+    """Enqueue a device rename as a background job and return the job.
 
-
-async def _rename_device_async():
-    """Async implementation of rename_device.
-
-    When renaming a device, also updates all entity friendly names that belong
-    to this device by replacing the old device name with the new one.
+    Renaming a device cascades to all its entities, which can take long enough to
+    exceed the Ingress/proxy timeout. Input is validated and sanitized here in the
+    request thread (the worker thread has no request context); the work itself
+    runs in the background worker and the frontend polls the returned job.
     """
     data = request.json
     is_valid, error = validate_json_input(data, ["device_id", "new_name"])
@@ -2382,189 +2456,215 @@ async def _rename_device_async():
     if not new_name:
         return jsonify({"error": "Invalid device name"}), 400
 
+    # Do not rename the same device twice concurrently.
+    for existing in renamer_state["job_store"].list_unfinished():
+        if existing.get("type") == "rename_device" and existing.get("payload", {}).get("device_id") == device_id:
+            return (
+                jsonify({"error": "A rename for this device is already in progress", "job_id": existing["job_id"]}),
+                409,
+            )
+
+    job = new_job("rename_device", {"device_id": device_id, "new_name": new_name}, job_id=uuid.uuid4().hex)
+    renamer_state["job_store"].save(job)
+    renamer_state["worker"].enqueue(job)
+    return jsonify(job), 202
+
+
+async def rename_device_handler(job, ctx):
+    """Rename a device and cascade the rename to all of its entities.
+
+    Renames the device, aligns the Z2M friendly name, then for every entity of
+    the device rebuilds its friendly name and entity id and rewrites references
+    in automations/scenes/scripts. Progress is reported per entity so the UI can
+    show a live bar. Runs inside the worker, which already holds the registry
+    lock, so it must not acquire it again.
+    """
+    payload = job["payload"]
+    device_id = payload["device_id"]
+    new_name = payload["new_name"]
+
+    base_url = os.getenv("HA_URL")
+    token = os.getenv("HA_TOKEN")
+    ws_url = base_url.replace("https://", "wss://").replace("http://", "ws://") + "/api/websocket"
+
+    ws = HomeAssistantWebSocket(ws_url, token)
+    await ws.connect()
+
     try:
-        # Erstelle WebSocket Verbindung
-        base_url = os.getenv("HA_URL")
-        token = os.getenv("HA_TOKEN")
-        ws_url = base_url.replace("https://", "wss://").replace("http://", "ws://") + "/api/websocket"
+        # Ensure restructurer is loaded
+        if renamer_state["restructurer"] is None:
+            renamer_state["restructurer"] = EntityRestructurer()
+        await renamer_state["restructurer"].load_structure(ws)
 
-        ws = HomeAssistantWebSocket(ws_url, token)
-        await ws.connect()
+        # Get old device name before renaming
+        old_device_name = None
+        if device_id in renamer_state["restructurer"].devices:
+            device = renamer_state["restructurer"].devices[device_id]
+            old_device_name = device.get("name_by_user") or device.get("name")
 
-        try:
-            # Ensure restructurer is loaded
-            if renamer_state["restructurer"] is None:
-                renamer_state["restructurer"] = EntityRestructurer()
-            await renamer_state["restructurer"].load_structure(ws)
+        device_registry = DeviceRegistry(ws)
+        success = await device_registry.rename_device(device_id, new_name)
 
-            # Get old device name before renaming
-            old_device_name = None
-            if device_id in renamer_state["restructurer"].devices:
-                device = renamer_state["restructurer"].devices[device_id]
-                old_device_name = device.get("name_by_user") or device.get("name")
+        if not success:
+            raise RuntimeError("Failed to rename device in Home Assistant")
 
-            device_registry = DeviceRegistry(ws)
-            success = await device_registry.rename_device(device_id, new_name)
+        # Align the Z2M friendly name with the new name (Z2M devices only, non-fatal)
+        z2m_sync = await _sync_z2m_name(device_registry, device_id, new_name)
 
-            if not success:
-                return (
-                    jsonify({"error": "Fehler beim Umbenennen des Geräts in Home Assistant"}),
-                    500,
+        # Update entities: rename ID + friendly name + update dependencies
+        entities_updated = 0
+        entities_failed = 0
+        entities_skipped = 0
+        dependencies_updated = 0
+
+        logger.info("=== Starting entity rename after device rename ===")
+        logger.info(f"Device ID: {device_id}")
+        logger.info(f"Old device name: {old_device_name}")
+        logger.info(f"New device name: {new_name}")
+
+        entity_registry = EntityRegistry(ws)
+
+        # Initialize dependency updater
+        dependency_updater = DependencyUpdater(base_url, token)
+        cached_states = await dependency_updater.get_states()
+
+        # Get area name for this device
+        device_info = renamer_state["restructurer"].devices.get(device_id, {})
+        area_id = device_info.get("area_id")
+        area_name = ""
+        if area_id and area_id in renamer_state["restructurer"].areas:
+            area_name = renamer_state["restructurer"].areas[area_id].get("name", "")
+
+        logger.info(f"Area ID: {area_id}, Area name: {area_name}")
+
+        # Get the device base_name (without area prefix)
+        device_base_name = _strip_prefix(new_name, area_name) if area_name else new_name
+
+        # Build old device display name for stripping from entity names
+        old_device_base = (
+            _strip_prefix(old_device_name, area_name) if (old_device_name and area_name) else old_device_name
+        )
+        old_device_display = f"{area_name} {old_device_base}" if area_name else old_device_base
+
+        # Count entities for this device
+        device_entities = [
+            eid for eid, einfo in renamer_state["restructurer"].entities.items() if einfo.get("device_id") == device_id
+        ]
+        total = len(device_entities)
+        logger.info(f"Found {total} entities for device {device_id}")
+        ctx.progress(0, total)
+        processed = 0
+
+        # Find all entities belonging to this device
+        for old_entity_id, entity_info in list(renamer_state["restructurer"].entities.items()):
+            if entity_info.get("device_id") != device_id:
+                continue
+
+            # Get current entity name
+            original_name = entity_info.get("name") or entity_info.get("original_name") or ""
+            logger.info(f"Processing entity {old_entity_id}: original_name='{original_name}'")
+
+            if not original_name:
+                logger.info("  Skipping - no original_name")
+                entities_skipped += 1
+                processed += 1
+                ctx.progress(processed, total, current=old_entity_id)
+                continue
+
+            # Compute entity base_name (suffix) by stripping area and device prefixes
+            entity_suffix = original_name
+            if old_device_display:
+                entity_suffix = _strip_prefix(entity_suffix, old_device_display)
+            if entity_suffix == original_name and old_device_base:
+                entity_suffix = _strip_prefix(entity_suffix, old_device_base)
+            if entity_suffix == original_name and area_name:
+                entity_suffix = _strip_prefix(entity_suffix, area_name)
+
+            # Build new friendly name: Area + Device Base + Entity Suffix
+            parts = []
+            if area_name:
+                parts.append(area_name)
+            parts.append(device_base_name)
+            if entity_suffix and entity_suffix != original_name:
+                parts.append(entity_suffix)
+
+            new_friendly_name = " ".join(parts)
+
+            # Build new entity ID
+            domain = old_entity_id.split(".")[0]
+            new_entity_id = f"{domain}.{normalize_name(new_friendly_name)}"
+
+            logger.info(f"  {old_entity_id} -> {new_entity_id} ('{new_friendly_name}')")
+
+            # Skip if nothing would change
+            if new_entity_id == old_entity_id and new_friendly_name == original_name:
+                logger.info("  Skipping - no changes needed")
+                entities_skipped += 1
+                processed += 1
+                ctx.progress(processed, total, current=old_entity_id)
+                continue
+
+            try:
+                # Rename entity (ID + friendly name)
+                id_changed = new_entity_id != old_entity_id
+                await entity_registry.rename_entity(
+                    old_entity_id, new_entity_id if id_changed else None, new_friendly_name
                 )
+                entities_updated += 1
+                logger.info("  SUCCESS: Renamed entity")
+                ctx.log("RENAME", f"{old_entity_id} -> {new_entity_id}")
 
-            # Z2M-friendly_name an den neuen Namen angleichen (nur Z2M-Geräte, nicht fatal)
-            z2m_sync = await _sync_z2m_name(device_registry, device_id, new_name)
-
-            # Update entities: rename ID + friendly name + update dependencies
-            entities_updated = 0
-            entities_failed = 0
-            entities_skipped = 0
-            dependencies_updated = 0
-
-            logger.info("=== Starting entity rename after device rename ===")
-            logger.info(f"Device ID: {device_id}")
-            logger.info(f"Old device name: {old_device_name}")
-            logger.info(f"New device name: {new_name}")
-
-            entity_registry = EntityRegistry(ws)
-
-            # Initialize dependency updater
-            base_url = os.getenv("HA_URL")
-            token = os.getenv("HA_TOKEN")
-            dependency_updater = DependencyUpdater(base_url, token)
-            cached_states = await dependency_updater.get_states()
-
-            # Get area name for this device
-            device_info = renamer_state["restructurer"].devices.get(device_id, {})
-            area_id = device_info.get("area_id")
-            area_name = ""
-            if area_id and area_id in renamer_state["restructurer"].areas:
-                area_name = renamer_state["restructurer"].areas[area_id].get("name", "")
-
-            logger.info(f"Area ID: {area_id}, Area name: {area_name}")
-
-            # Get the device base_name (without area prefix)
-            device_base_name = _strip_prefix(new_name, area_name) if area_name else new_name
-
-            # Build old device display name for stripping from entity names
-            old_device_base = (
-                _strip_prefix(old_device_name, area_name) if (old_device_name and area_name) else old_device_name
-            )
-            old_device_display = f"{area_name} {old_device_base}" if area_name else old_device_base
-
-            # Count entities for this device
-            device_entities = [
-                eid
-                for eid, einfo in renamer_state["restructurer"].entities.items()
-                if einfo.get("device_id") == device_id
-            ]
-            logger.info(f"Found {len(device_entities)} entities for device {device_id}")
-
-            # Find all entities belonging to this device
-            for old_entity_id, entity_info in list(renamer_state["restructurer"].entities.items()):
-                if entity_info.get("device_id") != device_id:
-                    continue
-
-                # Get current entity name
-                original_name = entity_info.get("name") or entity_info.get("original_name") or ""
-                logger.info(f"Processing entity {old_entity_id}: original_name='{original_name}'")
-
-                if not original_name:
-                    logger.info("  Skipping - no original_name")
-                    entities_skipped += 1
-                    continue
-
-                # Compute entity base_name (suffix) by stripping area and device prefixes
-                entity_suffix = original_name
-                if old_device_display:
-                    entity_suffix = _strip_prefix(entity_suffix, old_device_display)
-                if entity_suffix == original_name and old_device_base:
-                    entity_suffix = _strip_prefix(entity_suffix, old_device_base)
-                if entity_suffix == original_name and area_name:
-                    entity_suffix = _strip_prefix(entity_suffix, area_name)
-
-                # Build new friendly name: Area + Device Base + Entity Suffix
-                parts = []
-                if area_name:
-                    parts.append(area_name)
-                parts.append(device_base_name)
-                if entity_suffix and entity_suffix != original_name:
-                    parts.append(entity_suffix)
-
-                new_friendly_name = " ".join(parts)
-
-                # Build new entity ID
-                domain = old_entity_id.split(".")[0]
-                new_entity_id = f"{domain}.{normalize_name(new_friendly_name)}"
-
-                logger.info(f"  {old_entity_id} -> {new_entity_id} ('{new_friendly_name}')")
-
-                # Skip if nothing would change
-                if new_entity_id == old_entity_id and new_friendly_name == original_name:
-                    logger.info("  Skipping - no changes needed")
-                    entities_skipped += 1
-                    continue
-
-                try:
-                    # Rename entity (ID + friendly name)
-                    id_changed = new_entity_id != old_entity_id
-                    await entity_registry.rename_entity(
-                        old_entity_id, new_entity_id if id_changed else None, new_friendly_name
+                # Update dependencies if ID changed
+                if id_changed:
+                    dep_results = await dependency_updater.update_all_dependencies(
+                        old_entity_id, new_entity_id, cached_states
                     )
-                    entities_updated += 1
-                    logger.info("  SUCCESS: Renamed entity")
+                    dep_count = dep_results.get("total_success", 0)
+                    dependencies_updated += dep_count
+                    if dep_count > 0:
+                        logger.info(f"  Updated {dep_count} dependencies")
 
-                    # Update dependencies if ID changed
-                    if id_changed:
-                        dep_results = await dependency_updater.update_all_dependencies(
-                            old_entity_id, new_entity_id, cached_states
-                        )
-                        dep_count = dep_results.get("total_success", 0)
-                        dependencies_updated += dep_count
-                        if dep_count > 0:
-                            logger.info(f"  Updated {dep_count} dependencies")
+            except Exception as e:
+                entities_failed += 1
+                logger.error(f"  FAILED: {e}")
+                ctx.log("ERROR", f"{old_entity_id}: {e}")
 
-                except Exception as e:
-                    entities_failed += 1
-                    logger.error(f"  FAILED: {e}")
+            processed += 1
+            ctx.progress(processed, total, current=old_entity_id)
 
-            # Reload structure to reflect changes
-            await renamer_state["restructurer"].load_structure(ws)
+        # Reload structure to reflect changes
+        await renamer_state["restructurer"].load_structure(ws)
 
-            logger.info("=== Entity rename complete ===")
-            logger.info(
-                f"Updated: {entities_updated}, Failed: {entities_failed}, Skipped: {entities_skipped}, Dependencies: {dependencies_updated}"
-            )
+        logger.info("=== Entity rename complete ===")
+        logger.info(
+            f"Updated: {entities_updated}, Failed: {entities_failed}, "
+            f"Skipped: {entities_skipped}, Dependencies: {dependencies_updated}"
+        )
 
-            message = f"Gerät erfolgreich umbenannt zu: {new_name}"
-            if entities_updated > 0:
-                message += f" ({entities_updated} Entities"
-                if dependencies_updated > 0:
-                    message += f", {dependencies_updated} Dependencies"
-                message += " aktualisiert)"
-            if entities_failed > 0:
-                message += f" ({entities_failed} fehlgeschlagen)"
+        message = f"Device renamed to: {new_name}"
+        if entities_updated > 0:
+            message += f" ({entities_updated} entities"
+            if dependencies_updated > 0:
+                message += f", {dependencies_updated} dependencies"
+            message += " updated)"
+        if entities_failed > 0:
+            message += f" ({entities_failed} failed)"
 
-            return jsonify(
-                {
-                    "success": True,
-                    "message": message,
-                    "entities_updated": entities_updated,
-                    "entities_failed": entities_failed,
-                    "dependencies_updated": dependencies_updated,
-                    "z2m_synced": z2m_sync.get("synced"),
-                    "z2m_failed": (
-                        z2m_sync.get("error") if z2m_sync.get("supported") and not z2m_sync.get("synced") else None
-                    ),
-                }
-            )
+        return {
+            "success": True,
+            "message": message,
+            "entities_updated": entities_updated,
+            "entities_failed": entities_failed,
+            "dependencies_updated": dependencies_updated,
+            "z2m_synced": z2m_sync.get("synced"),
+            "z2m_failed": (z2m_sync.get("error") if z2m_sync.get("supported") and not z2m_sync.get("synced") else None),
+        }
 
-        finally:
-            await ws.disconnect()
+    finally:
+        await ws.disconnect()
 
-    except Exception as e:
-        logger.error(f"Fehler beim Umbenennen des Geräts: {e}")
-        return jsonify({"error": str(e)}), 500
+
+renamer_state["worker"].register("rename_device", rename_device_handler)
 
 
 @app.route("/api/sync_z2m_name", methods=["POST"])
@@ -3057,6 +3157,26 @@ async def _swap_devices_async():
     return jsonify({"devices": devices})
 
 
+@app.route("/api/jobs", methods=["GET"])
+def jobs_unfinished():
+    """List unfinished background jobs (for reconnect after a reload).
+
+    Read-only: this must not take the registry lock so it stays responsive
+    while a long-running job holds the lock. Atomic writes guarantee readers
+    see a complete old-or-new job file.
+    """
+    return jsonify({"jobs": renamer_state["job_store"].list_unfinished()})
+
+
+@app.route("/api/jobs/<job_id>", methods=["GET"])
+def job_get(job_id):
+    """Return the current state of a background job (for polling)."""
+    job = renamer_state["job_store"].load(job_id)
+    if not job:
+        return jsonify({"error": "Job not found"}), 404
+    return jsonify(job)
+
+
 @app.route("/api/swap/jobs", methods=["GET"])
 def swap_jobs():
     """Nicht abgeschlossene Swap-Jobs (für Resume)."""
@@ -3191,22 +3311,38 @@ def swap_confirm(job_id):
 
 @app.route("/api/swap/<job_id>/execute", methods=["POST"])
 def swap_execute(job_id):
-    """Führt den Job aus bzw. setzt ihn fort (idempotent)."""
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(_swap_execute_async(job_id))
-    finally:
-        loop.close()
+    """Enqueue swap execution/continuation as a background job (idempotent).
 
-
-async def _swap_execute_async(job_id):
+    The swap keeps its own persisted state machine and resume flow in swap_store;
+    the worker just runs it under the shared registry lock. The frontend polls
+    api/swap/<job_id> for progress. Returns the swap job so the UI can start
+    polling immediately.
+    """
     store = renamer_state["swap_store"]
     job = store.load(job_id)
     if not job:
         return jsonify({"error": "Job not found"}), 404
     if job["state"] in (device_swap.STATE_PROPOSED, device_swap.STATE_ABORTED, device_swap.STATE_COMPLETED):
         return jsonify({"error": f"Job not runnable in state {job['state']}"}), 409
+
+    generic = new_job("swap", {"swap_job_id": job_id}, job_id=uuid.uuid4().hex)
+    renamer_state["job_store"].save(generic)
+    renamer_state["worker"].enqueue(generic)
+    return jsonify(job), 202
+
+
+async def swap_execute_handler(job, ctx):
+    """Run/continue a device swap inside the worker.
+
+    Loads the swap job from swap_store and drives its SwapExecutor state machine.
+    The executor persists progress per step/entity in swap_store (which the UI
+    polls); this generic wrapper job only records that the run happened.
+    """
+    swap_job_id = job["payload"]["swap_job_id"]
+    store = renamer_state["swap_store"]
+    swap_job = store.load(swap_job_id)
+    if not swap_job:
+        raise RuntimeError(f"Swap job {swap_job_id} not found")
 
     client = await init_client()
     states = await client.get_states()
@@ -3230,11 +3366,14 @@ async def _swap_execute_async(job_id):
             timestamp=_iso_now(),
             lovelace_updater=LovelaceUpdater(ws),
         )
-        job = await executor.run(job)
+        swap_job = await executor.run(swap_job)
     finally:
         await ws.disconnect()
 
-    return jsonify(job)
+    return {"swap_job_id": swap_job_id, "final_state": swap_job.get("state")}
+
+
+renamer_state["worker"].register("swap", swap_execute_handler)
 
 
 @app.route("/api/swap/<job_id>/abort", methods=["POST"])
@@ -3258,6 +3397,11 @@ if __name__ == "__main__":
     # In Add-on mode, use port 5000 for Ingress
     port = int(os.getenv("WEB_UI_PORT", 5000))
     print(f"\nStarting Web UI on port {port}\n")
+
+    # Fail any generic jobs left running by a previous process, then start the
+    # background worker before serving requests.
+    renamer_state["worker"].reconcile_on_start()
+    renamer_state["worker"].start()
 
     # Run without debug in production
     app.run(debug=False, host="0.0.0.0", port=port)

--- a/web_ui.py
+++ b/web_ui.py
@@ -165,9 +165,9 @@ renamer_state = {
     "rename_log": RenameLog(os.path.join(DATA_DIR, "rename_log.jsonl")),
     "api_token_store": ApiTokenStore(os.path.join(DATA_DIR, "api_token.json")),
     # Generic background-job infrastructure for long-running operations. Jobs run
-    # serially on a single worker thread; requests keep serving concurrently
-    # (load_structure rebuilds the restructurer by reassignment and handlers work
-    # on snapshots, so no cross-thread lock is needed).
+    # serially on a single worker thread, off the request path (load_structure
+    # rebuilds the restructurer by reassignment and handlers work on snapshots,
+    # so no cross-thread lock is needed).
     "job_store": JobStore(os.path.join(DATA_DIR, "jobs"), terminal_states=TERMINAL_STATES),
 }
 renamer_state["worker"] = JobWorker(renamer_state["job_store"])
@@ -1351,7 +1351,7 @@ def execute_direct():
 async def execute_direct_handler(job, ctx):
     """Apply a batch of entity renames, reporting progress per entity.
 
-    Runs inside the worker (which holds the registry lock). Renames each entity
+    Runs inside the worker (serial, off the request path). Renames each entity
     (id + friendly name), enables disabled ones when configured, and rewrites
     references in automations/scenes/scripts. Returns the same result shape the
     endpoint used to return so the UI summary is unchanged.
@@ -2476,8 +2476,7 @@ async def rename_device_handler(job, ctx):
     Renames the device, aligns the Z2M friendly name, then for every entity of
     the device rebuilds its friendly name and entity id and rewrites references
     in automations/scenes/scripts. Progress is reported per entity so the UI can
-    show a live bar. Runs inside the worker, which already holds the registry
-    lock, so it must not acquire it again.
+    show a live bar. Runs inside the worker (serial, off the request path).
     """
     payload = job["payload"]
     device_id = payload["device_id"]
@@ -3161,9 +3160,8 @@ async def _swap_devices_async():
 def jobs_unfinished():
     """List unfinished background jobs (for reconnect after a reload).
 
-    Read-only: this must not take the registry lock so it stays responsive
-    while a long-running job holds the lock. Atomic writes guarantee readers
-    see a complete old-or-new job file.
+    Read-only and cheap, so it stays responsive while a long-running job is in
+    flight. Atomic writes guarantee readers see a complete old-or-new job file.
     """
     return jsonify({"jobs": renamer_state["job_store"].list_unfinished()})
 
@@ -3314,7 +3312,7 @@ def swap_execute(job_id):
     """Enqueue swap execution/continuation as a background job (idempotent).
 
     The swap keeps its own persisted state machine and resume flow in swap_store;
-    the worker just runs it under the shared registry lock. The frontend polls
+    the worker just runs it serially, off the request path. The frontend polls
     api/swap/<job_id> for progress. Returns the swap job so the UI can start
     polling immediately.
     """


### PR DESCRIPTION
## Problem

Long-running registry operations ran synchronously inside the Flask request and exceeded the Ingress/proxy timeout on large devices (e.g. renaming a device with ~70 entities). The client got an error toast while the work silently continued to completion — no progress, no result. The device swap and batch apply had the same latent weakness.

## Solution

A shared, Flask-agnostic background-job layer and all long-runners moved onto it.

**New `jobs.py`**
- `JobStore` — atomic JSON job files (extracted/generalized from `SwapJobStore`, which now subclasses it)
- `JobContext` — throttled progress + log persistence
- `JobWorker` — a single serial worker thread with one long-lived asyncio loop; `reconcile_on_start` fails jobs left running by a restart

**Backend (`web_ui.py`)**
- `rename_device`, `execute_direct`, new `enable_all`, and `swap execute` now enqueue and return `202 { job }`
- New `GET /api/jobs` (reconnect) and `GET /api/jobs/<id>` (poll)
- Swap keeps its own persisted state machine + resume; the worker just runs it

**Frontend (`templates/index.html`)**
- Generic `jobPanel`: progress bar, current item, collapsible/height-limited log tail
- Reconnects to a running job after a page reload (before the hierarchy load)
- On success the panel closes and a self-dismissing toast confirms; partial/hard failures stay visible

**Notes / deliberate choices**
- No `registry_lock`: the worker is serial and `load_structure` rebuilds by reassignment while handlers iterate over snapshots, so a lock only caused the hierarchy endpoint to block behind a running job (504) — removed.
- `/api/execute` (preview-based) left synchronous: it has no frontend caller, so changing its contract would add risk with no benefit.

## Verification
- `tests/test_jobs.py` (store, throttled progress, worker success/failure/serial, reconcile) + `tests/test_web_rename_job.py` (request-thread enqueue/validation/409/poll)
- Full suite green (88), black/isort/flake8 clean, inline JS syntax-checked
- Verified end-to-end against a live Home Assistant add-on: large device rename with live progress, reload-reconnect, and success toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
