### PR TITLE
chore: emit Renovate commits as `deps:` for changelog visibility

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Allowed types — only feat/fix produce a release (minor/patch);
-          # the rest are changelog-visible but non-releasing.
+          # the rest are changelog-visible but non-releasing. `deps` is what
+          # Renovate emits (see renovate.json) and release-please renders it as
+          # a "Dependencies" changelog section by default.
           types: |
             feat
             fix
@@ -31,3 +33,4 @@ jobs:
             refactor
             perf
             build
+            deps

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   "baseBranchPatterns": [
     "main"
   ],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "deps",
+  "semanticCommitScope": null,
   "constraints": {
     "python": "3.14"
   },


### PR DESCRIPTION
## Why

Renovate committed dependency updates as `chore(deps):`, and release-please hides `chore` from the changelog by default. That's why release notes only ever showed Features — the bulk of merged traffic was invisible `chore(deps):` commits.

## What

- **`renovate.json`**: switch Renovate to the `deps:` commit type (no scope) via `semanticCommitType`/`semanticCommitScope`. release-please renders `deps` as a **"Dependencies"** changelog section by default, so no `release-please-config.json` change is needed.
- **`.github/workflows/pr-title.yml`**: add `deps` to the allowed Conventional Commit types so Renovate PR titles keep passing the `pr-title` gate (and auto-merge keeps working).

## Behaviour

- `deps` produces **no** semver label → dependency updates stay non-releasing, identical to the old `chore` behaviour.
- Other `chore` commits (`chore(deploy)`, generic `chore:`) remain hidden — only real dependency updates surface.
- Applies to **future** Renovate PRs only; already-merged `chore(deps):` commits are not backfilled.
- The "Dependencies" section first appears in the next release cut by a releasing (`feat`/`fix`) commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)